### PR TITLE
Add docs and deployment scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,9 @@ This project contains a simple subscription smart contract written in Solidity a
 - Node.js
 - npm
 
-## Installation
+## Setup
+
+Clone the repository and install dependencies:
 
 ```bash
 npm install
@@ -19,13 +21,30 @@ npm install
 npm test
 ```
 
-Note: downloading the Solidity compiler requires network access. In restricted environments the tests may fail to compile.
+_The Solidity compiler and dependencies are fetched during the first run. In network-restricted environments these steps can fail._
+
+## Deployment
+
+Two deployment scripts are provided under `scripts/`.
+
+- **Testnet** – `scripts/deploy-testnet.ts`
+- **Mainnet** – `scripts/deploy-mainnet.ts`
+
+Both scripts read configuration from environment variables such as `MERCHANT_ADDRESS`, `TOKEN_ADDRESS`, `PRICE_FEED`, `BILLING_CYCLE`, `PRICE_IN_USD`, `FIXED_PRICE` and `USD_PRICE`.
+
+Example deployment to a testnet network configured in `hardhat.config.ts`:
+
+```bash
+npx hardhat run scripts/deploy-testnet.ts --network sepolia
+```
 
 ## Contracts
 
 - `Subscription.sol` – core subscription logic. Uses `Ownable2Step` and `SafeERC20`.
 - `MockV3Aggregator.sol` – mock oracle implementing the Chainlink Aggregator interface.
 - `MockToken.sol` – simple ERC20 token for testing.
+
+Additional documentation can be found in the [docs](docs/) directory.
 
 ## License
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,18 @@
+# Contract Architecture
+
+The core of this repository is `Subscription.sol`. The contract lets merchants create subscription plans that users can subscribe to. Payments can be denominated in the payment token itself or specified in USD cents and converted to token amounts using a Chainlink price feed.
+
+### Key Components
+
+- **SubscriptionPlan struct** – holds merchant address, payment token, billing cycle and pricing information.
+- **UserSubscription struct** – records each subscriber's status and the date their next payment is due.
+- **Mappings**
+  - `plans` map plan IDs to `SubscriptionPlan` data.
+  - `userSubscriptions` track subscriptions for each user and plan.
+- **Functions**
+  - `createPlan` – owner-only function to define a new plan.
+  - `subscribe` – user function that transfers the first payment and records the subscription.
+  - `processPayment` – merchant function to charge recurring payments.
+  - `cancelSubscription` – subscriber function to cancel an active plan.
+
+The project also contains `MockToken.sol` and `MockV3Aggregator.sol` for local testing. These mocks emulate an ERC20 token and a Chainlink price feed.

--- a/docs/usage-examples.md
+++ b/docs/usage-examples.md
@@ -1,0 +1,32 @@
+# Usage Examples
+
+Below are small snippets showing how to interact with the Subscription contract from a Hardhat script or console.
+
+## Creating a Plan
+```ts
+const subscription = await ethers.getContract("Subscription");
+await subscription.createPlan(
+  merchant.address,
+  token.address,
+  ethers.utils.parseUnits("10", 18), // token price
+  30 * 24 * 60 * 60,                 // billing cycle in seconds
+  false,                             // priceInUsd
+  0,
+  ethers.constants.AddressZero
+);
+```
+
+## Subscribing
+```ts
+await subscription.connect(user).subscribe(0);
+```
+
+## Processing Recurring Payment
+```ts
+await subscription.connect(merchant).processPayment(user.address, 0);
+```
+
+## Cancelling a Subscription
+```ts
+await subscription.connect(user).cancelSubscription(0);
+```

--- a/scripts/deploy-mainnet.ts
+++ b/scripts/deploy-mainnet.ts
@@ -1,0 +1,34 @@
+import { ethers } from "hardhat";
+
+async function main() {
+  const merchant = process.env.MERCHANT_ADDRESS || ethers.constants.AddressZero;
+  const token = process.env.TOKEN_ADDRESS || ethers.constants.AddressZero;
+  const priceFeed = process.env.PRICE_FEED || ethers.constants.AddressZero;
+  const billingCycle = parseInt(process.env.BILLING_CYCLE || "2592000", 10);
+  const priceInUsd = process.env.PRICE_IN_USD === "true";
+  const fixedPrice = process.env.FIXED_PRICE || "0";
+  const usdPrice = parseInt(process.env.USD_PRICE || "0", 10);
+
+  const SubscriptionFactory = await ethers.getContractFactory("Subscription");
+  const subscription = await SubscriptionFactory.deploy();
+  console.log("Subscription deployed to:", subscription.address);
+
+  if (token !== ethers.constants.AddressZero) {
+    const tx = await subscription.createPlan(
+      merchant,
+      token,
+      fixedPrice,
+      billingCycle,
+      priceInUsd,
+      usdPrice,
+      priceFeed
+    );
+    await tx.wait();
+    console.log("Initial plan created");
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/scripts/deploy-testnet.ts
+++ b/scripts/deploy-testnet.ts
@@ -1,0 +1,34 @@
+import { ethers } from "hardhat";
+
+async function main() {
+  const merchant = process.env.MERCHANT_ADDRESS || ethers.constants.AddressZero;
+  const token = process.env.TOKEN_ADDRESS || ethers.constants.AddressZero;
+  const priceFeed = process.env.PRICE_FEED || ethers.constants.AddressZero;
+  const billingCycle = parseInt(process.env.BILLING_CYCLE || "2592000", 10); // default 30 days
+  const priceInUsd = process.env.PRICE_IN_USD === "true";
+  const fixedPrice = process.env.FIXED_PRICE || "0";
+  const usdPrice = parseInt(process.env.USD_PRICE || "0", 10);
+
+  const SubscriptionFactory = await ethers.getContractFactory("Subscription");
+  const subscription = await SubscriptionFactory.deploy();
+  console.log("Subscription deployed to:", subscription.address);
+
+  if (token !== ethers.constants.AddressZero) {
+    const tx = await subscription.createPlan(
+      merchant,
+      token,
+      fixedPrice,
+      billingCycle,
+      priceInUsd,
+      usdPrice,
+      priceFeed
+    );
+    await tx.wait();
+    console.log("Initial plan created");
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- document the Subscription contract architecture
- show usage examples
- add deployment scripts for testnet and mainnet
- expand README with setup, testing and deployment instructions

## Testing
- `npm test` *(fails: hardhat not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861571ced1083338e3ea7997be59200