### PR TITLE
Add pausable access control

### DIFF
--- a/contracts/Subscription.sol
+++ b/contracts/Subscription.sol
@@ -4,9 +4,11 @@ pragma solidity ^0.8.0;
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "@openzeppelin/contracts/access/Ownable2Step.sol"; // Changed from Ownable
+import "@openzeppelin/contracts/access/AccessControl.sol";
+import "@openzeppelin/contracts/utils/Pausable.sol";
 import "./interfaces/AggregatorV3Interface.sol"; // Changed to local import
 
-contract Subscription is Ownable2Step { // Changed from Ownable
+contract Subscription is Ownable2Step, AccessControl, Pausable { // Changed from Ownable
     using SafeERC20 for IERC20;
 
     /**
@@ -36,6 +38,9 @@ contract Subscription is Ownable2Step { // Changed from Ownable
     mapping(uint256 => SubscriptionPlan) public plans;
     /// @notice Counter for the next available plan ID.
     uint256 public nextPlanId;
+
+    /// @notice Role identifier for accounts that can pause and unpause the contract
+    bytes32 public constant PAUSER_ROLE = keccak256("PAUSER_ROLE");
 
     /**
      * @title User Subscription Details
@@ -96,9 +101,28 @@ contract Subscription is Ownable2Step { // Changed from Ownable
     event SubscriptionCancelled(address indexed user, uint256 indexed planId);
 
     /**
+     * @notice Pause subscription-related actions.
+     * @dev Callable only by accounts with PAUSER_ROLE.
+     */
+    function pause() external onlyRole(PAUSER_ROLE) {
+        _pause();
+    }
+
+    /**
+     * @notice Unpause subscription-related actions.
+     * @dev Callable only by accounts with PAUSER_ROLE.
+     */
+    function unpause() external onlyRole(PAUSER_ROLE) {
+        _unpause();
+    }
+
+    /**
      * @notice Contract constructor. Initializes Ownable2Step with the deployer as the initial owner.
      */
-    constructor() Ownable2Step(msg.sender) {}
+    constructor() Ownable2Step(msg.sender) {
+        _grantRole(DEFAULT_ADMIN_ROLE, msg.sender);
+        _grantRole(PAUSER_ROLE, msg.sender);
+    }
 
     /**
      * @notice Creates a new subscription plan.
@@ -177,7 +201,7 @@ contract Subscription is Ownable2Step { // Changed from Ownable
      * @dev Transfers initial payment from user to merchant. User must approve contract for token spending.
      * @param _planId The ID of the plan to subscribe to.
      */
-    function subscribe(uint256 _planId) public {
+    function subscribe(uint256 _planId) public whenNotPaused {
         require(plans[_planId].merchant != address(0), "Plan does not exist"); 
         require(!userSubscriptions[msg.sender][_planId].isActive, "Already actively subscribed to this plan");
 
@@ -208,7 +232,7 @@ contract Subscription is Ownable2Step { // Changed from Ownable
      * @param _user The address of the subscriber whose payment is being processed.
      * @param _planId The ID of the plan for which payment is processed.
      */
-    function processPayment(address _user, uint256 _planId) public {
+    function processPayment(address _user, uint256 _planId) public whenNotPaused {
        UserSubscription storage userSub = userSubscriptions[_user][_planId];
        SubscriptionPlan storage plan = plans[_planId];
 
@@ -232,7 +256,7 @@ contract Subscription is Ownable2Step { // Changed from Ownable
      * @dev Sets the subscription to inactive. No refunds for the current billing cycle.
      * @param _planId The ID of the plan to cancel.
      */
-    function cancelSubscription(uint256 _planId) public {
+    function cancelSubscription(uint256 _planId) public whenNotPaused {
         UserSubscription storage userSub = userSubscriptions[msg.sender][_planId];
 
         require(userSub.subscriber == msg.sender, "Not subscribed to this plan or subscription data mismatch");


### PR DESCRIPTION
## Summary
- add OpenZeppelin `Pausable` and `AccessControl`
- introduce `PAUSER_ROLE` with pause/unpause functions
- guard subscription actions with `whenNotPaused`
- test pause behaviour

## Testing
- `npm test` *(fails: couldn't download compiler)*

------
https://chatgpt.com/codex/tasks/task_e_6861571985488333a7e5d5c46f83a15a