### PR TITLE
Use local solc for offline tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ npm install
 npm test
 ```
 
-Note: downloading the Solidity compiler requires network access. In restricted environments the tests may fail to compile.
+Tests use a locally installed Solidity compiler and no longer require network access.
 
 ## Contracts
 

--- a/contracts/Subscription.sol
+++ b/contracts/Subscription.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.0;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "@openzeppelin/contracts/access/Ownable2Step.sol"; // Changed from Ownable
 import "./interfaces/AggregatorV3Interface.sol"; // Changed to local import
@@ -98,7 +99,7 @@ contract Subscription is Ownable2Step { // Changed from Ownable
     /**
      * @notice Contract constructor. Initializes Ownable2Step with the deployer as the initial owner.
      */
-    constructor() Ownable2Step(msg.sender) {}
+    constructor() Ownable(msg.sender) {}
 
     /**
      * @notice Creates a new subscription plan.
@@ -126,7 +127,7 @@ contract Subscription is Ownable2Step { // Changed from Ownable
         }
         require(_token != address(0), "Token address cannot be zero");
 
-        IERC20 tokenContract = IERC20(_token);
+        IERC20Metadata tokenContract = IERC20Metadata(_token);
         uint8 tokenDecimals = tokenContract.decimals();
 
         address merchant = (_merchantAddress == address(0)) ? msg.sender : _merchantAddress;

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -1,5 +1,20 @@
-import { HardhatUserConfig } from "hardhat/config";
+import { HardhatUserConfig, subtask } from "hardhat/config";
+import { TASK_COMPILE_SOLIDITY_GET_SOLC_BUILD } from "hardhat/builtin-tasks/task-names";
+import { SolcBuild } from "hardhat/types";
+
 import "@nomicfoundation/hardhat-toolbox";
+
+// Use local solc instead of downloading it
+subtask(TASK_COMPILE_SOLIDITY_GET_SOLC_BUILD)
+  .setAction(async ({ solcVersion }: { solcVersion: string; quiet: boolean }): Promise<SolcBuild> => {
+    const solcPath = require.resolve("solc/soljson.js");
+    return {
+      compilerPath: solcPath,
+      isSolcJs: true,
+      version: solcVersion,
+      longVersion: solcVersion,
+    };
+  });
 
 const config: HardhatUserConfig = {
   solidity: {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "hardhat-project",
   "devDependencies": {
     "@nomicfoundation/hardhat-toolbox": "^5.0.0",
-    "hardhat": "^2.22.4"
+    "hardhat": "^2.22.4",
+    "solc": "^0.8.26"
   },
   "scripts": {
     "compile": "hardhat compile",

--- a/test/Subscription.ts
+++ b/test/Subscription.ts
@@ -16,7 +16,7 @@ describe("Subscription Contract", function () {
         // No need to call mockToken.deployed() with ethers v6, await on deploy() is enough
 
         // Mint some tokens to user1 and anotherUser for testing
-        const initialUserBalance = ethers.utils.parseUnits("1000", 18);
+        const initialUserBalance = ethers.parseUnits("1000", 18);
         await mockToken.mint(user1.address, initialUserBalance);
         await mockToken.mint(anotherUser.address, initialUserBalance);
 
@@ -26,8 +26,8 @@ describe("Subscription Contract", function () {
         
         // User1 approves the subscription contract to spend their mock tokens
         // Approve a large amount for simplicity in tests
-        await mockToken.connect(user1).approve(subscriptionContract.address, ethers.utils.parseUnits("5000", 18));
-        await mockToken.connect(anotherUser).approve(subscriptionContract.address, ethers.utils.parseUnits("5000", 18));
+        await mockToken.connect(user1).approve(subscriptionContract.address, ethers.parseUnits("5000", 18));
+        await mockToken.connect(anotherUser).approve(subscriptionContract.address, ethers.parseUnits("5000", 18));
 
         // Deploy MockV3Aggregator
         const MockAggregatorFactory = await ethers.getContractFactory("MockV3Aggregator", owner);
@@ -61,7 +61,7 @@ describe("Subscription Contract", function () {
 
         it("Should allow owner to create a fixed price plan (merchant is owner) and emit PlanCreated event", async function () {
             const { subscriptionContract, mockToken, owner } = await loadFixture(deploySubscriptionFixture);
-            const fixedPrice = ethers.utils.parseUnits("10", mockTokenDecimals);
+            const fixedPrice = ethers.parseUnits("10", mockTokenDecimals);
             const billingCycle = THIRTY_DAYS_IN_SECS;
 
             await expect(subscriptionContract.connect(owner).createPlan(
@@ -115,7 +115,7 @@ describe("Subscription Contract", function () {
 
         it("Should default merchant to owner if address(0) is provided for merchantAddress", async function () {
             const { subscriptionContract, mockToken, owner } = await loadFixture(deploySubscriptionFixture);
-            const fixedPrice = ethers.utils.parseUnits("5", mockTokenDecimals);
+            const fixedPrice = ethers.parseUnits("5", mockTokenDecimals);
             await subscriptionContract.connect(owner).createPlan(
                 ethers.constants.AddressZero, // merchantAddress
                 mockToken.address, fixedPrice, THIRTY_DAYS_IN_SECS, false, 0, ethers.constants.AddressZero
@@ -148,7 +148,7 @@ describe("Subscription Contract", function () {
 
     describe("subscribe (Fixed Price Plan)", function () {
         const planId = 0;
-        const fixedPrice = ethers.utils.parseUnits("10", 18); // mockTokenDecimals is 18
+        const fixedPrice = ethers.parseUnits("10", 18); // mockTokenDecimals is 18
         const billingCycle = THIRTY_DAYS_IN_SECS;
 
         async function fixtureWithFixedPlan() {
@@ -228,7 +228,7 @@ describe("Subscription Contract", function () {
                     .mul(await (await mockAggregator.latestRoundData()).answer)
                 );
             
-            expect(expectedTokenAmount).to.equal(ethers.utils.parseUnits("0.005", 18));
+            expect(expectedTokenAmount).to.equal(ethers.parseUnits("0.005", 18));
 
 
             await expect(subscriptionContract.connect(user1).subscribe(planId))
@@ -257,7 +257,7 @@ describe("Subscription Contract", function () {
 
     describe("processPayment (Fixed Price Plan)", function () {
         const planId = 0;
-        const fixedPrice = ethers.utils.parseUnits("10", 18);
+        const fixedPrice = ethers.parseUnits("10", 18);
         const billingCycle = THIRTY_DAYS_IN_SECS;
 
         async function fixtureWithActiveFixedSubscription() {
@@ -398,7 +398,7 @@ describe("Subscription Contract", function () {
                     ethers.BigNumber.from(100) // To convert cents to dollars
                     .mul(newOraclePrice) // newOraclePrice is already price * 10^oracleDecimals
                 );
-            expect(expectedTokenAmount).to.equal(ethers.utils.parseUnits("0.004", tokenDecimals)); // 0.004 MTK for $10 at $2500/MTK
+            expect(expectedTokenAmount).to.equal(ethers.parseUnits("0.004", tokenDecimals)); // 0.004 MTK for $10 at $2500/MTK
 
             // Process payment by owner (who is the merchant for this plan)
             await expect(subscriptionContract.connect(owner).processPayment(user1.address, planId))
@@ -445,7 +445,7 @@ describe("Subscription Contract", function () {
 
 describe("cancelSubscription", function () {
     const planId = 0;
-    const fixedPrice = ethers.utils.parseUnits("10", 18);
+    const fixedPrice = ethers.parseUnits("10", 18);
     const billingCycle = THIRTY_DAYS_IN_SECS;
 
     async function fixtureWithActiveSubscriptionForCancel() {


### PR DESCRIPTION
## Summary
- install `solc` as a dev dependency
- configure Hardhat to load `solc` from `node_modules`
- update README to note tests run without network
- adjust contract and tests for latest dependencies

## Testing
- `npm test` *(fails: ReferenceError: deploySubscriptionFixture is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6861571385f883338d825a7021e5417d