### PR TITLE
Add updatePlan capability

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,12 @@ npm run solhint
 
 Additional documentation can be found in the [docs](docs/) directory.
 
+## Updating Plans
+
+The contract owner can modify existing subscription plans using `updatePlan`.
+This function lets you change the billing cycle, price, USD price and price feed
+address. A `PlanUpdated` event is emitted when a plan is changed.
+
 ## License
 
 Released under the MIT License. See [LICENSE](LICENSE).

--- a/docs/usage-examples.md
+++ b/docs/usage-examples.md
@@ -30,3 +30,15 @@ await subscription.connect(merchant).processPayment(user.address, 0);
 ```ts
 await subscription.connect(user).cancelSubscription(0);
 ```
+
+## Updating a Plan
+```ts
+await subscription.updatePlan(
+  0,                              // planId
+  60 * 60 * 24 * 60,             // new billing cycle
+  ethers.utils.parseUnits("20", 18), // new price
+  false,                         // priceInUsd
+  0,
+  ethers.constants.AddressZero
+);
+```


### PR DESCRIPTION
## Summary
- add `updatePlan` with `PlanUpdated` event
- test plan updates
- document plan updates in README and usage examples

## Testing
- `npm test` *(fails: Couldn't download compiler version list)*

------
https://chatgpt.com/codex/tasks/task_e_686184ef3b148333bf7fb3e72662f081