### PR TITLE
Document pauser role

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,27 @@ npm run solhint
 
 Additional documentation can be found in the [docs](docs/) directory.
 
+## Access Control
+
+`Subscription.sol` uses OpenZeppelin's `AccessControl` to manage privileged
+functions. The deployer is granted both `DEFAULT_ADMIN_ROLE` and `PAUSER_ROLE`.
+Accounts with the pauser role can pause or unpause the contract.
+
+Grant the role to another account:
+
+```bash
+npx hardhat console --network <network>
+> const sub = await ethers.getContractAt("Subscription", "<address>")
+> const role = await sub.PAUSER_ROLE()
+> await sub.grantRole(role, "0xPAUSER")
+```
+
+Revoke it when no longer needed:
+
+```bash
+> await sub.revokeRole(role, "0xPAUSER")
+```
+
 ## Updating Plans
 
 The contract owner can modify existing subscription plans using `updatePlan`.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -16,3 +16,9 @@ The core of this repository is `Subscription.sol`. The contract lets merchants c
   - `cancelSubscription` – subscriber function to cancel an active plan.
 
 The project also contains `MockToken.sol` and `MockV3Aggregator.sol` for local testing. These mocks emulate an ERC20 token and a Chainlink price feed.
+
+### Access Control
+
+`Subscription.sol` relies on OpenZeppelin's `AccessControl`. The deployer
+receives `DEFAULT_ADMIN_ROLE` and `PAUSER_ROLE`. Accounts with `PAUSER_ROLE`
+can pause or unpause the contract when needed.


### PR DESCRIPTION
## Summary
- document the `PAUSER_ROLE` in the README
- mention default admin role is assigned to the deployer
- describe AccessControl usage in architecture docs

## Testing
- `npx hardhat compile` *(fails: couldn't download compiler version list)*

------
https://chatgpt.com/codex/tasks/task_e_68618b2d2b588333837958b9e8a53491