### PR TITLE
Fix gitignore to track lockfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@ node_modules/
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
-package-lock.json
 yarn.lock
 
 # Build artifacts

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,3 +14,7 @@ slither .
 ```
 
 Pull requests should not introduce any high severity Slither findings.
+
+The `package-lock.json` file tracks exact dependency versions and must remain
+committed to the repository. If you add or update dependencies, make sure to
+commit the updated lockfile in the same pull request.


### PR DESCRIPTION
## Summary
- keep `package-lock.json` in the repo
- document lockfile policy in `CONTRIBUTING.md`

## Testing
- `npm install`
- `npm test` *(fails: Couldn't download compiler version list)*

------
https://chatgpt.com/codex/tasks/task_e_68618b2de7188333b3e9c77ca34ed059