### PR TITLE
Clarify lockfile policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,3 +18,6 @@ Pull requests should not introduce any high severity Slither findings.
 The `package-lock.json` file tracks exact dependency versions and must remain
 committed to the repository. If you add or update dependencies, make sure to
 commit the updated lockfile in the same pull request.
+
+Any change to `package-lock.json` must be included in your commit, even if the
+dependency versions appear unchanged.


### PR DESCRIPTION
## Summary
- document that changes to `package-lock.json` must always be committed

No `.gitignore` entry for `package-lock.json` existed, so no change was needed.

## Testing
- `npm test` *(fails: couldn't download compiler)*

------
https://chatgpt.com/codex/tasks/task_e_68618f973590833388504e841c708521