### PR TITLE
Add automated payment processing script

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,28 @@ The contract owner can modify existing subscription plans using `updatePlan`.
 This function lets you change the billing cycle, price, USD price and price feed
 address. A `PlanUpdated` event is emitted when a plan is changed.
 
+## Processing Due Payments
+
+The script `scripts/process-due-payments.ts` reads a list of subscribers and
+executes `processPayment` for those whose `nextPaymentDate` has passed. Any
+failures are logged to the console.
+
+### Running via Hardhat
+
+Use Hardhat to execute the script:
+
+```bash
+npx hardhat run scripts/process-due-payments.ts --network <network>
+```
+
+### Cron Example
+
+To automate processing, add a cron entry. This example runs hourly:
+
+```cron
+0 * * * * cd /path/to/project && npx hardhat run scripts/process-due-payments.ts --network <network> >> cron.log 2>&1
+```
+
 ## License
 
 Released under the MIT License. See [LICENSE](LICENSE).

--- a/scripts/process-due-payments.ts
+++ b/scripts/process-due-payments.ts
@@ -1,0 +1,38 @@
+import { ethers } from "hardhat";
+import fs from "fs";
+import path from "path";
+
+async function main() {
+  const contractAddress = process.env.SUBSCRIPTION_ADDRESS;
+  if (!contractAddress) {
+    throw new Error("SUBSCRIPTION_ADDRESS not set");
+  }
+  const planId = parseInt(process.env.PLAN_ID || "0", 10);
+  const listPath = process.env.SUBSCRIBERS_FILE || path.join(__dirname, "subscribers.json");
+
+  const provider = ethers.provider;
+  const merchantPk = process.env.MERCHANT_PRIVATE_KEY;
+  const signer = merchantPk ? new ethers.Wallet(merchantPk, provider) : (await ethers.getSigners())[0];
+  const subscription = await ethers.getContractAt("Subscription", contractAddress, signer);
+
+  const subscribers: string[] = JSON.parse(fs.readFileSync(listPath, "utf8"));
+  const now = Math.floor(Date.now() / 1000);
+
+  for (const user of subscribers) {
+    try {
+      const sub = await subscription.userSubscriptions(user, planId);
+      if (sub.isActive && sub.nextPaymentDate.toNumber() <= now) {
+        const tx = await subscription.processPayment(user, planId);
+        await tx.wait();
+        console.log(`Processed payment for ${user}`);
+      }
+    } catch (err) {
+      console.error(`Failed to process payment for ${user}:`, err);
+    }
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- add `process-due-payments.ts` script to process recurring payments
- document cron/Hardhat usage for the script in README

## Testing
- `npm test` *(fails: couldn't download compiler)*

------
https://chatgpt.com/codex/tasks/task_e_686199275b3c83338755f41c41ee30e1