### PR TITLE
Add subgraph preparation script

### DIFF
--- a/docs/usage-examples.md
+++ b/docs/usage-examples.md
@@ -77,15 +77,18 @@ query the data, follow these steps:
    docker compose up
    ```
 
-3. In another terminal, generate and deploy the subgraph:
+3. In another terminal, generate and deploy the subgraph. First create a
+   local manifest by replacing the placeholders in `subgraph.yaml`:
 
    ```bash
+   NETWORK=<network> CONTRACT_ADDRESS=<address> \
+     npx ts-node scripts/prepare-subgraph.ts
    npm run codegen
-   npm run build-subgraph
+   graph build subgraph/subgraph.local.yaml
    graph deploy \
      --node http://localhost:8020/ \
      --ipfs http://localhost:5001/ \
-     subscription-subgraph subgraph/subgraph.yaml
+     subscription-subgraph subgraph/subgraph.local.yaml
    ```
 
 4. Query the subgraph via GraphiQL at

--- a/scripts/prepare-subgraph.ts
+++ b/scripts/prepare-subgraph.ts
@@ -1,0 +1,20 @@
+import fs from 'fs';
+import path from 'path';
+
+const network = process.env.NETWORK;
+const address = process.env.CONTRACT_ADDRESS;
+
+if (!network || !address) {
+  console.error('NETWORK and CONTRACT_ADDRESS env vars must be set');
+  process.exit(1);
+}
+
+const inputPath = path.join(__dirname, '../subgraph/subgraph.yaml');
+const outputPath = path.join(__dirname, '../subgraph/subgraph.local.yaml');
+
+let yaml = fs.readFileSync(inputPath, 'utf8');
+yaml = yaml.replace(/{{NETWORK}}/g, network).replace(/{{CONTRACT_ADDRESS}}/g, address);
+
+fs.writeFileSync(outputPath, yaml);
+console.log(`Wrote ${outputPath}`);
+

--- a/subgraph/subgraph.yaml
+++ b/subgraph/subgraph.yaml
@@ -4,9 +4,9 @@ schema:
 dataSources:
   - kind: ethereum
     name: Subscription
-    network: mainnet
+    network: {{NETWORK}}
     source:
-      address: "0x0000000000000000000000000000000000000000"
+      address: "{{CONTRACT_ADDRESS}}"
       abi: Subscription
       startBlock: 0
     mapping:


### PR DESCRIPTION
## Summary
- inject placeholders for network and address in `subgraph.yaml`
- provide `scripts/prepare-subgraph.ts` to replace placeholders and create `subgraph.local.yaml`
- document how to build and deploy the subgraph using the script

## Testing
- `npm test` *(fails: hardhat not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861a760155883339a2b282cd5c5bc2f