### PR TITLE
Add subscribers schema example

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,15 @@ passed. Any failures are logged to the console.
 
 The file must contain a JSON array of Ethereum addresses. See
 [`scripts/subscribers.example.json`](scripts/subscribers.example.json) for an
-example.
+example. The required schema is simply an array of strings, e.g.
+
+```json
+[
+  "0x1111111111111111111111111111111111111111",
+  "0x2222222222222222222222222222222222222222",
+  "0x3333333333333333333333333333333333333333"
+]
+```
 
 ### Running via Hardhat
 


### PR DESCRIPTION
## Summary
- document the JSON schema for the subscriber list in README

## Testing
- `npm test` *(fails: hardhat not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861b41d40b08333a94c2901553c11db