### PR TITLE
Make contract loading async

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -3,9 +3,9 @@
 This directory contains a simple Next.js application that interacts with the
 `Subscription` smart contract using [`ethers.js`](https://docs.ethers.org/).
 
-## Setup
+## Installation
 
-Install dependencies:
+Install dependencies in this directory:
 
 ```bash
 npm install
@@ -18,6 +18,8 @@ NEXT_PUBLIC_CONTRACT_ADDRESS=0xYourContractAddress
 # Optional RPC provider used when MetaMask is not available
 NEXT_PUBLIC_RPC_URL=https://sepolia.infura.io/v3/YOUR_KEY
 ```
+
+## Start
 
 Run the development server:
 

--- a/frontend/app/manage/page.tsx
+++ b/frontend/app/manage/page.tsx
@@ -9,7 +9,7 @@ export default function Manage() {
 
   async function subscribe() {
     try {
-      const contract = getContract();
+      const contract = await getContract();
       await contract.subscribe(BigInt(planId));
     } catch (err) {
       console.error(err);
@@ -18,7 +18,7 @@ export default function Manage() {
 
   async function cancel() {
     try {
-      const contract = getContract();
+      const contract = await getContract();
       await contract.cancelSubscription(BigInt(planId));
     } catch (err) {
       console.error(err);

--- a/frontend/app/payment/page.tsx
+++ b/frontend/app/payment/page.tsx
@@ -10,7 +10,7 @@ export default function Payment() {
 
   async function trigger() {
     try {
-      const contract = getContract();
+      const contract = await getContract();
       await contract.processPayment(user, BigInt(planId));
     } catch (err) {
       console.error(err);

--- a/frontend/app/plans/page.tsx
+++ b/frontend/app/plans/page.tsx
@@ -21,7 +21,7 @@ export default function Plans() {
   useEffect(() => {
     async function load() {
       try {
-        const contract = getContract();
+        const contract = await getContract();
         const nextId: bigint = await contract.nextPlanId();
         const list: Plan[] = [];
         for (let i = 0n; i < nextId; i++) {

--- a/frontend/lib/contract.ts
+++ b/frontend/lib/contract.ts
@@ -1,13 +1,14 @@
 import { ethers } from "ethers";
 import abi from "./subscriptionAbi";
 
-export function getContract() {
+export async function getContract() {
   const address = process.env.NEXT_PUBLIC_CONTRACT_ADDRESS;
   if (!address) throw new Error("NEXT_PUBLIC_CONTRACT_ADDRESS is not defined");
   let signerOrProvider: ethers.Signer | ethers.Provider;
   if (typeof window !== "undefined" && (window as any).ethereum) {
     const provider = new ethers.BrowserProvider((window as any).ethereum);
-    signerOrProvider = provider.getSigner();
+    const signer = await provider.getSigner();
+    signerOrProvider = signer;
   } else {
     const rpc = process.env.NEXT_PUBLIC_RPC_URL;
     if (!rpc) throw new Error("RPC provider not available");


### PR DESCRIPTION
## Summary
- use async `getContract()` in the frontend
- update all pages to await the promise
- document install and start steps in the frontend README

## Testing
- `npm --prefix frontend run lint` *(fails: Unexpected any)*
- `npm test` *(fails: Hardhat compilation failed)*

------
https://chatgpt.com/codex/tasks/task_e_6861be5677748333aaafa6ce86d7301d