### PR TITLE
Update subgraph ABI path and docs

### DIFF
--- a/docs/usage-examples.md
+++ b/docs/usage-examples.md
@@ -1,6 +1,6 @@
 # Usage Examples
 
-Below are small snippets showing how to interact with the Subscription contract from a Hardhat script or console.
+Below are small snippets showing how to interact with the Subscription contract from a Hardhat script or console. The contract is deployed as an upgradeable proxy (`SubscriptionUpgradeable`).
 
 ## Creating a Plan
 ```ts
@@ -59,7 +59,8 @@ await subscription.updatePlan(
 ## Running the Subgraph Locally
 
 The `subgraph/` folder contains a basic [The Graph](https://thegraph.com) setup
-that indexes events from `Subscription.sol`. To start a local Graph node and
+that indexes events from the upgradeable `SubscriptionUpgradeable.sol` contract.
+To start a local Graph node and
 query the data, follow these steps:
 
 1. Install the Graph CLI:

--- a/scripts/prepare-subgraph.ts
+++ b/scripts/prepare-subgraph.ts
@@ -13,7 +13,13 @@ const inputPath = path.join(__dirname, '../subgraph/subgraph.yaml');
 const outputPath = path.join(__dirname, '../subgraph/subgraph.local.yaml');
 
 let yaml = fs.readFileSync(inputPath, 'utf8');
-yaml = yaml.replace(/{{NETWORK}}/g, network).replace(/{{CONTRACT_ADDRESS}}/g, address);
+yaml = yaml
+  .replace(/{{NETWORK}}/g, network)
+  .replace(/{{CONTRACT_ADDRESS}}/g, address)
+  .replace(
+    /..\/artifacts\/contracts\/Subscription\.sol\/Subscription\.json/g,
+    '../artifacts/contracts/SubscriptionUpgradeable.sol/SubscriptionUpgradeable.json'
+  );
 
 fs.writeFileSync(outputPath, yaml);
 console.log(`Wrote ${outputPath}`);

--- a/subgraph/subgraph.yaml
+++ b/subgraph/subgraph.yaml
@@ -19,7 +19,7 @@ dataSources:
         - Payment
       abis:
         - name: Subscription
-          file: ../artifacts/contracts/Subscription.sol/Subscription.json
+          file: ../artifacts/contracts/SubscriptionUpgradeable.sol/SubscriptionUpgradeable.json
       eventHandlers:
         - event: PlanCreated(uint256,address,address,uint8,uint256,uint256,bool,uint256,address)
           handler: handlePlanCreated


### PR DESCRIPTION
## Summary
- update ABI location in `subgraph.yaml`
- make `prepare-subgraph.ts` replace the ABI path so the generated manifest uses the upgradeable contract
- document upgradeable proxy in usage examples

## Testing
- `node node_modules/hardhat/internal/cli/cli.js test` *(fails: unsupported addressable value)*
- `npm run lint` *(fails: ESLint couldn't find configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68623dc360188333a765b68c036d526d