### PR TITLE
Update tests for ethers v6

### DIFF
--- a/test/Subscription.ts
+++ b/test/Subscription.ts
@@ -14,7 +14,7 @@ describe("Subscription Contract", function () {
         // Deploy MockToken
         const MockTokenFactory = await ethers.getContractFactory("MockToken", owner); // Deploy with owner
         const mockToken = await MockTokenFactory.deploy("Mock Token", "MTK", 18);
-        // No need to call mockToken.deployed() with ethers v6, await on deploy() is enough
+        await mockToken.waitForDeployment();
 
         // Mint some tokens to user1 and anotherUser for testing
         const initialUserBalance = ethers.parseUnits("1000", 18);
@@ -24,6 +24,7 @@ describe("Subscription Contract", function () {
         // Deploy Subscription contract
         const SubscriptionFactory = await ethers.getContractFactory("Subscription", owner); // Deploy with owner
         const subscriptionContract = (await SubscriptionFactory.deploy()) as Subscription;
+        await subscriptionContract.waitForDeployment();
         
         // User1 approves the subscription contract to spend their mock tokens
         // Approve a large amount for simplicity in tests
@@ -35,6 +36,7 @@ describe("Subscription Contract", function () {
         // 8 decimals for price feed (common for USD pairs), initial price $2000 / token
         const initialOraclePrice = ethers.BigNumber.from("2000").mul(ethers.BigNumber.from("10").pow(8)); 
         const mockAggregator = await MockAggregatorFactory.deploy(8, initialOraclePrice);
+        await mockAggregator.waitForDeployment();
 
         return { subscriptionContract, mockToken, mockAggregator, owner, user1, merchant, anotherUser, initialUserBalance, initialOraclePrice };
     }
@@ -261,9 +263,11 @@ describe("Subscription Contract", function () {
             const [owner, user1] = await ethers.getSigners();
             const PermitFactory = await ethers.getContractFactory("PermitToken", owner);
             const permitToken = await PermitFactory.deploy("Permit Token", "PTK");
+            await permitToken.waitForDeployment();
 
             const SubscriptionFactory = await ethers.getContractFactory("Subscription", owner);
             const subscription = (await SubscriptionFactory.deploy()) as Subscription;
+            await subscription.waitForDeployment();
 
             const amount = ethers.parseUnits("1000", 18);
             await permitToken.mint(user1.address, amount);
@@ -816,9 +820,11 @@ describe("Reentrancy protection", function () {
 
         const MaliciousTokenFactory = await ethers.getContractFactory("MaliciousToken", owner);
         const maliciousToken = await MaliciousTokenFactory.deploy("Malicious Token", "MAL", 18);
+        await maliciousToken.waitForDeployment();
 
         const SubscriptionFactory = await ethers.getContractFactory("Subscription", owner);
         const subscriptionContract = (await SubscriptionFactory.deploy()) as Subscription;
+        await subscriptionContract.waitForDeployment();
 
         const amount = ethers.parseUnits("100", 18);
         await maliciousToken.mint(user1.address, amount);

--- a/test/SubscriptionUpgradeable.ts
+++ b/test/SubscriptionUpgradeable.ts
@@ -1,6 +1,10 @@
 import { expect } from "chai";
 import { ethers, upgrades } from "hardhat";
 import { loadFixture, time } from "@nomicfoundation/hardhat-network-helpers";
+import type {
+  SubscriptionUpgradeable,
+  SubscriptionUpgradeableV2,
+} from "../typechain";
 
 const PLAN_ID = 0;
 
@@ -13,7 +17,11 @@ async function deployUpgradeableFixture() {
   await token.mint(user.address, ethers.parseUnits("1000", 18));
 
   const SubV1 = await ethers.getContractFactory("SubscriptionUpgradeable", owner);
-  const proxy = await upgrades.deployProxy(SubV1, [owner.address], { initializer: "initialize" });
+  const proxy = (await upgrades.deployProxy(
+    SubV1,
+    [owner.address],
+    { initializer: "initialize" }
+  )) as SubscriptionUpgradeable;
   await proxy.waitForDeployment();
 
   await token.connect(user).approve(await proxy.getAddress(), ethers.parseUnits("1000", 18));
@@ -37,7 +45,10 @@ describe("SubscriptionUpgradeable upgrade", function () {
     await time.increase(cycle + 1);
 
     const SubV2 = await ethers.getContractFactory("SubscriptionUpgradeableV2", owner);
-    const upgraded = await upgrades.upgradeProxy(await proxy.getAddress(), SubV2);
+    const upgraded = (await upgrades.upgradeProxy(
+      await proxy.getAddress(),
+      SubV2
+    )) as SubscriptionUpgradeableV2;
     await upgraded.waitForDeployment();
 
     expect(await upgraded.version()).to.equal("v2");


### PR DESCRIPTION
## Summary
- tweak SubscriptionUpgradeable tests for typed contracts
- wait for contract deployments to finish in Subscription tests

## Testing
- `npx hardhat test` *(fails: unsupported addressable value)*

------
https://chatgpt.com/codex/tasks/task_e_68623dc2e8e08333ac5032dc3ffd229c