### PR TITLE
Add frontend docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,12 @@ npm run build-subgraph
 
 See [docs/usage-examples.md](docs/usage-examples.md) for instructions on running a local Graph node.
 
+## Frontend
+
+The repository also contains a simple Next.js application under
+[`frontend/`](frontend/). Follow the instructions in
+[`frontend/README.md`](frontend/README.md) to run the interface.
+
 ## License
 
 Released under the MIT License. See [LICENSE](LICENSE).

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -11,13 +11,13 @@ Install dependencies in this directory:
 npm install
 ```
 
-Copy `.env.local.example` to `.env.local` and enter the contract address and an optional RPC URL:
+## Environment Variables
+
+Copy `.env.local.example` to `.env.local` and set the required contract address. Optionally provide an RPC URL used when no wallet is available:
 
 ```bash
 cp .env.local.example .env.local
-```
 
-```bash
 NEXT_PUBLIC_CONTRACT_ADDRESS=0xYourContractAddress
 # Optional RPC provider used when MetaMask is not available
 NEXT_PUBLIC_RPC_URL=https://sepolia.infura.io/v3/YOUR_KEY


### PR DESCRIPTION
## Summary
- document the frontend in the project root README
- clarify environment variables and dev server startup in `frontend/README.md`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68624a9dbdb483338dfc777e095fe136