### PR TITLE
Enable Etherscan verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,18 @@ Example deployment to a testnet network configured in `hardhat.config.ts`:
 npx hardhat run scripts/deploy-testnet.ts --network sepolia
 ```
 
+## Contract Verification
+
+After deployment you can verify both proxy and implementation contracts using the
+script `scripts/verify.ts`:
+
+```bash
+npx hardhat run scripts/verify.ts --network <network>
+```
+
+Make sure `ETHERSCAN_API_KEY` is set in your environment so the Hardhat verify
+plugin can submit the contract source to the block explorer.
+
 ## Static Analysis
 
 Install [Slither](https://github.com/crytic/slither) using `pip`:

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -1,5 +1,6 @@
 import { HardhatUserConfig } from "hardhat/config";
 import "@nomicfoundation/hardhat-toolbox";
+import "@nomicfoundation/hardhat-verify";
 import "@openzeppelin/hardhat-upgrades";
 import "@typechain/hardhat";
 
@@ -17,6 +18,9 @@ const config: HardhatUserConfig = {
   typechain: {
     outDir: "typechain",
     target: "ethers-v6",
+  },
+  etherscan: {
+    apiKey: process.env.ETHERSCAN_API_KEY || "",
   },
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       },
       "devDependencies": {
         "@nomicfoundation/hardhat-toolbox": "^5.0.0",
+        "@nomicfoundation/hardhat-verify": "^2.0.14",
         "@openzeppelin/hardhat-upgrades": "^3.0.0",
         "@typechain/ethers-v6": "^0.5.1",
         "@typechain/hardhat": "^9.1.0",
@@ -2816,7 +2817,6 @@
       "integrity": "sha512-z3iVF1WYZHzcdMMUuureFpSAfcnlfJbJx3faOnGrOYg6PRTki1Ut9JAuRccnFzMHf1AmTEoSUpWcyvBCoxL5Rg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ethersproject/abi": "^5.1.2",
         "@ethersproject/address": "^5.0.2",
@@ -2838,7 +2838,6 @@
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -5458,7 +5457,6 @@
       "integrity": "sha512-DwGjNW9omn6EwP70aXsn7FQJx5kO12tX0bZkaTjzdVFM6/7nhA4t0EENocKGx6D2Bch9PE2KzCUf5SceBdeijg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nofilter": "^3.1.0"
       },
@@ -10290,8 +10288,7 @@
       "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
       "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/lodash.isequal": {
       "version": "4.5.0",

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "hardhat-project",
   "devDependencies": {
     "@nomicfoundation/hardhat-toolbox": "^5.0.0",
+    "@nomicfoundation/hardhat-verify": "^2.0.14",
     "@openzeppelin/hardhat-upgrades": "^3.0.0",
     "@typechain/ethers-v6": "^0.5.1",
     "@typechain/hardhat": "^9.1.0",

--- a/scripts/verify.ts
+++ b/scripts/verify.ts
@@ -1,0 +1,19 @@
+import { run } from "hardhat";
+
+async function main() {
+  const proxy = process.env.SUBSCRIPTION_ADDRESS || "";
+  const implementation = process.env.IMPLEMENTATION_ADDRESS || "";
+
+  if (proxy) {
+    await run("verify:verify", { address: proxy });
+  }
+
+  if (implementation) {
+    await run("verify:verify", { address: implementation });
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- install `@nomicfoundation/hardhat-verify`
- configure `hardhat.config.ts` with the verify plugin and `ETHERSCAN_API_KEY`
- add `scripts/verify.ts` to verify proxy and implementation
- document contract verification in README

## Testing
- `npm test` *(fails: unsupported addressable value)*

------
https://chatgpt.com/codex/tasks/task_e_68624a985c6c8333a4a128b917e0c820