### PR TITLE
Add upgrade script

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,11 @@ To automate processing, add a cron entry. This example runs hourly:
 Der Vertrag `SubscriptionUpgradeable` wird über einen Transparent Proxy bereitgestellt.
 Mit dem Hardhat-Upgrades-Plugin kann ein neues Implementierungscontract einfach über `upgradeProxy` eingespielt werden.
 Ein Beispiel findet sich im Test `test/SubscriptionUpgradeable.ts`.
+Für reale Deployments steht das Skript `scripts/upgrade.ts` bereit, welches die Proxy-Adresse aus `SUBSCRIPTION_ADDRESS` liest und auf `SubscriptionUpgradeableV2` oder spätere Versionen aktualisiert.
+
+```bash
+npx hardhat run scripts/upgrade.ts --network <network>
+```
 
 ## Subgraph
 

--- a/scripts/upgrade.ts
+++ b/scripts/upgrade.ts
@@ -1,0 +1,20 @@
+import { ethers, upgrades } from "hardhat";
+
+async function main() {
+  const proxy = process.env.SUBSCRIPTION_ADDRESS;
+  if (!proxy) {
+    throw new Error("SUBSCRIPTION_ADDRESS not set");
+  }
+
+  const SubV2 = await ethers.getContractFactory("SubscriptionUpgradeableV2");
+  const upgraded = await upgrades.upgradeProxy(proxy, SubV2);
+  await upgraded.waitForDeployment();
+
+  const impl = await upgrades.erc1967.getImplementationAddress(proxy);
+  console.log("Upgraded implementation at:", impl);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- add upgrade script using OpenZeppelin upgrades
- explain upgrade process in README

## Testing
- `npm test` *(fails: unsupported addressable value)*

------
https://chatgpt.com/codex/tasks/task_e_6862a514ff3c8333b9b7c420b8379d5d