### PR TITLE
Remove obsolete comment block

### DIFF
--- a/test/Subscription.ts
+++ b/test/Subscription.ts
@@ -737,10 +737,6 @@ describe("Subscription Contract", function () {
                 .to.be.reverted;
         });
     });
-    // Keep existing general failure tests for subscribe/processPayment (non-existent plan, not active, not due, insufficient funds/allowance)
-    // and adapt them if necessary or duplicate for USD plans if behavior might differ.
-    // For example, "Should revert if subscribing to a non-existent plan" is generic.
-    // "Should revert if token transfer fails (insufficient balance)" needs to be tested for both fixed and dynamic pricing.
 });
 
 


### PR DESCRIPTION
## Summary
- clean up leftover comment block in Subscription test suite

## Testing
- `npm install`
- `npm test` *(fails: unsupported addressable value errors)*

------
https://chatgpt.com/codex/tasks/task_e_6863223d240083338cc9843bfd763cfa