### PR TITLE
Add subgraph tests to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,10 @@ jobs:
       with:
         node-version: '18'
     - run: npm install
+    - name: Install Graph testing dependencies
+      run: npm install -g @graphprotocol/graph-cli matchstick-as
     - run: npm run lint
     - run: npm run solhint
     - run: npm test
     - run: npm run coverage
+    - run: npm run test-subgraph


### PR DESCRIPTION
## Summary
- run graph CLI and matchstick testing dependencies in CI
- add subgraph tests step

## Testing
- `npm test` *(fails: unsupported addressable value)*
- `npm run lint` *(fails: ESLint couldn't find configuration)*

------
https://chatgpt.com/codex/tasks/task_e_6863223a62988333b6de3e2f826fa891