### PR TITLE
Update CI to lint and build frontend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,3 +30,9 @@ jobs:
     - run: npm test
     - run: npm run coverage
     - run: npm run test-subgraph
+    - name: Install frontend deps
+      run: npm install --prefix frontend
+    - name: Lint frontend
+      run: npm run lint --prefix frontend
+    - name: Build frontend
+      run: npm run build --prefix frontend


### PR DESCRIPTION
## Summary
- add steps for installing, linting and building the frontend in GitHub Actions

## Testing
- `npm install`
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm test` *(fails: 53 failing tests)*
- `npm run coverage` *(fails: 53 test(s) failed under coverage)*
- `npm run test-subgraph` *(fails: fetch failed)*
- `npm install --prefix frontend`
- `npm run lint --prefix frontend`
- `npm run build --prefix frontend` *(fails: module not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863a7270a488333b60e7fcaa49e4b35