### PR TITLE
Add Playwright end-to-end testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,3 +30,6 @@ jobs:
     - run: npm test
     - run: npm run coverage
     - run: npm run test-subgraph
+    - run: npm --prefix frontend install
+    - run: npm --prefix frontend run build
+    - run: npm run test:e2e

--- a/e2e/subscription.spec.ts
+++ b/e2e/subscription.spec.ts
@@ -1,0 +1,95 @@
+import { test, expect } from '@playwright/test';
+import { spawn, spawnSync } from 'child_process';
+import * as path from 'path';
+import { ethers } from 'ethers';
+import fs from 'fs';
+
+const rpcUrl = 'http://127.0.0.1:8545';
+
+let hardhat: any;
+let frontend: any;
+let provider: ethers.JsonRpcProvider;
+let subscription: ethers.Contract;
+let token: ethers.Contract;
+let owner: string;
+let user: string;
+
+test.beforeAll(async () => {
+  hardhat = spawn('npx', ['hardhat', 'node'], { stdio: 'inherit' });
+  await new Promise(res => setTimeout(res, 4000));
+
+  spawnSync('npx', ['hardhat', 'compile'], { stdio: 'inherit' });
+
+  provider = new ethers.JsonRpcProvider(rpcUrl);
+  const accounts = await provider.listAccounts();
+  owner = accounts[0];
+  user = accounts[1];
+  const ownerSigner = provider.getSigner(owner);
+  const userSigner = provider.getSigner(user);
+
+  const mockJson = JSON.parse(fs.readFileSync(path.join('artifacts','contracts','MockToken.sol','MockToken.json'), 'utf8'));
+  const subJson = JSON.parse(fs.readFileSync(path.join('artifacts','contracts','Subscription.sol','Subscription.json'), 'utf8'));
+
+  const tokenFactory = new ethers.ContractFactory(mockJson.abi, mockJson.bytecode, ownerSigner);
+  token = await tokenFactory.deploy('Mock', 'MOCK', 18);
+  await token.waitForDeployment();
+  await token.mint(user, ethers.parseUnits('1000', 18));
+
+  const subscriptionFactory = new ethers.ContractFactory(subJson.abi, subJson.bytecode, ownerSigner);
+  subscription = await subscriptionFactory.deploy();
+  await subscription.waitForDeployment();
+
+  await token.connect(userSigner).approve(await subscription.getAddress(), ethers.parseUnits('1000', 18));
+  await subscription.createPlan(owner, await token.getAddress(), ethers.parseUnits('10',18), 30*24*60*60, false,0, ethers.ZeroAddress);
+
+  frontend = spawn('npm', ['run', 'dev', '--', '-p', '3000'], {
+    cwd: path.join(__dirname, '..','frontend'),
+    env: { ...process.env, NEXT_PUBLIC_CONTRACT_ADDRESS: await subscription.getAddress(), NEXT_PUBLIC_RPC_URL: rpcUrl },
+    stdio: 'inherit',
+  });
+  await new Promise(res => setTimeout(res, 10000));
+});
+
+test.afterAll(() => {
+  if (frontend) frontend.kill();
+  if (hardhat) hardhat.kill();
+});
+
+test('complete flow', async ({ page }) => {
+  await page.addInitScript(() => {
+    window.ethereum = {
+      request: async ({ method, params }: { method: string; params?: unknown[] }) => {
+        const res = await fetch('http://127.0.0.1:8545', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ jsonrpc: '2.0', id: Date.now(), method, params }),
+        });
+        const json = await res.json();
+        if (json.error) throw new Error(json.error.message);
+        return json.result;
+      },
+    } as any;
+  });
+
+  await page.goto('/manage');
+  await page.click('text=Connect Wallet');
+  await page.fill('input', '0');
+  await page.click('text=Subscribe');
+
+  await expect.poll(async () => {
+    const sub = await subscription.userSubscriptions(user, 0);
+    return sub.isActive;
+  }).toBe(true);
+
+  const before = (await subscription.userSubscriptions(user, 0)).nextPaymentDate;
+  await page.goto('/payment');
+  const inputs = page.locator('input');
+  await inputs.nth(0).fill(user);
+  await inputs.nth(1).fill('0');
+  await page.click('text=Process');
+
+  await expect.poll(async () => {
+    const sub = await subscription.userSubscriptions(user, 0);
+    return sub.nextPaymentDate > before;
+  }).toBe(true);
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@nomicfoundation/hardhat-toolbox": "^5.0.0",
         "@nomicfoundation/hardhat-verify": "^2.0.14",
         "@openzeppelin/hardhat-upgrades": "^3.0.0",
+        "@playwright/test": "^1.53.2",
         "@typechain/ethers-v6": "^0.5.1",
         "@typechain/hardhat": "^9.1.0",
         "@types/node": "^24.0.7",
@@ -21,6 +22,7 @@
         "hardhat": "^2.22.4",
         "hardhat-coverage": "^0.9.19",
         "matchstick-as": "^0.6.0",
+        "playwright": "^1.53.2",
         "prettier": "^3.6.2",
         "solc": "^0.8.26",
         "solhint": "^5.2.0",
@@ -4323,6 +4325,22 @@
       "integrity": "sha512-xogeCEZ50XRMxpBwE3TZjJ8RCO8Guv39gDRrrKtlpDEDEMLm0MzD3A0SQObgj7aF7qTZNRTWzsuvQdxgzw25wQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.53.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.53.2.tgz",
+      "integrity": "sha512-tEB2U5z74ebBeyfGNZ3Jfg29AnW+5HlWhvHtb/Mqco9pFdZU1ZLNdVb2UtB5CvmiilNr2ZfVH/qMmAROG/XTzw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.53.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/@pnpm/config.env-replace": {
       "version": "1.1.0",
@@ -14407,6 +14425,53 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.53.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.53.2.tgz",
+      "integrity": "sha512-6K/qQxVFuVQhRQhFsVZ9fGeatxirtrpPgxzBYWyZLEXJzqYwuL4fuNmfOfD5et1tJE4GScKyPNeLhZeRwuTU3A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.53.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.53.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.53.2.tgz",
+      "integrity": "sha512-ox/OytMy+2w1jcYEYlOo1Hhp8hZkLCximMTUTMBXjGUA1KoFfiSZ+DU+3a739jsPY0yoKH2TFy9S2fsJas8yAw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/pluralize": {

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "@nomicfoundation/hardhat-toolbox": "^5.0.0",
     "@nomicfoundation/hardhat-verify": "^2.0.14",
     "@openzeppelin/hardhat-upgrades": "^3.0.0",
+    "@playwright/test": "^1.53.2",
     "@typechain/ethers-v6": "^0.5.1",
     "@typechain/hardhat": "^9.1.0",
     "@types/node": "^24.0.7",
@@ -12,6 +13,7 @@
     "hardhat": "^2.22.4",
     "hardhat-coverage": "^0.9.19",
     "matchstick-as": "^0.6.0",
+    "playwright": "^1.53.2",
     "prettier": "^3.6.2",
     "solc": "^0.8.26",
     "solhint": "^5.2.0",
@@ -27,7 +29,8 @@
     "codegen": "graph codegen subgraph/subgraph.yaml",
     "build-subgraph": "graph build subgraph/subgraph.yaml",
     "coverage": "hardhat coverage",
-    "test-subgraph": "graph test"
+    "test-subgraph": "graph test",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "@chainlink/contracts": "^1.4.0",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,12 @@
+import type { PlaywrightTestConfig } from '@playwright/test';
+
+const config: PlaywrightTestConfig = {
+  testDir: './e2e',
+  timeout: 60000,
+  use: {
+    baseURL: 'http://localhost:3000',
+    headless: true,
+  },
+};
+
+export default config;


### PR DESCRIPTION
## Summary
- install Playwright
- configure Playwright
- add an e2e test that spins up Hardhat and the frontend
- expose a `test:e2e` npm script
- run e2e tests in CI after building the frontend

## Testing
- `npm test` *(fails)*
- `npm run test:e2e` *(fails)*

------
https://chatgpt.com/codex/tasks/task_e_6863a72957e083339ba7342bdfa45d1f