### PR TITLE
Add billing cycle check

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,12 @@ The command sets `REPORT_GAS=true` and prints a table similar to:
 
 Additional documentation can be found in the [docs](docs/) directory.
 
+## Creating a Plan
+
+When calling `createPlan`, the `billingCycle` parameter must be greater than
+zero. Attempts to create or update a plan with `billingCycle = 0` will
+revert with `"Billing cycle must be > 0"`.
+
 ## Access Control
 
 `Subscription.sol` uses OpenZeppelin's `AccessControl` to manage privileged

--- a/contracts/Subscription.sol
+++ b/contracts/Subscription.sol
@@ -165,6 +165,7 @@ contract Subscription is Ownable2Step, AccessControl, Pausable, ReentrancyGuard 
         uint256 _usdPrice,
         address _priceFeedAddress
     ) public onlyOwner whenNotPaused {
+        require(_billingCycle > 0, "Billing cycle must be > 0");
         if (_priceInUsd) {
             require(_priceFeedAddress != address(0), "Price feed address required for USD pricing");
         }
@@ -210,6 +211,8 @@ contract Subscription is Ownable2Step, AccessControl, Pausable, ReentrancyGuard 
     ) public onlyOwner whenNotPaused {
         SubscriptionPlan storage plan = plans[_planId];
         require(plan.merchant != address(0), "Plan does not exist");
+
+        require(_billingCycle > 0, "Billing cycle must be > 0");
 
         if (_priceInUsd) {
             require(_priceFeedAddress != address(0), "Price feed address required for USD pricing");

--- a/contracts/SubscriptionUpgradeable.sol
+++ b/contracts/SubscriptionUpgradeable.sol
@@ -107,6 +107,7 @@ contract SubscriptionUpgradeable is
         uint256 _usdPrice,
         address _priceFeedAddress
     ) public onlyOwner whenNotPaused {
+        require(_billingCycle > 0, "Billing cycle must be > 0");
         if (_priceInUsd) {
             require(_priceFeedAddress != address(0), "Price feed address required for USD pricing");
         }
@@ -142,6 +143,8 @@ contract SubscriptionUpgradeable is
     ) public onlyOwner whenNotPaused {
         SubscriptionPlan storage plan = plans[_planId];
         require(plan.merchant != address(0), "Plan does not exist");
+
+        require(_billingCycle > 0, "Billing cycle must be > 0");
 
         if (_priceInUsd) {
             require(_priceFeedAddress != address(0), "Price feed address required for USD pricing");

--- a/test/Subscription.ts
+++ b/test/Subscription.ts
@@ -147,6 +147,19 @@ describe("Subscription Contract", function () {
                 owner.address, ethers.constants.AddressZero, 100, THIRTY_DAYS_IN_SECS, false, 0, ethers.constants.AddressZero
             )).to.be.revertedWith("Token address cannot be zero");
         });
+
+        it("Should revert if billingCycle is zero", async function () {
+            const { subscriptionContract, mockToken, owner } = await loadFixture(deploySubscriptionFixture);
+            await expect(subscriptionContract.connect(owner).createPlan(
+                owner.address,
+                mockToken.address,
+                1,
+                0,
+                false,
+                0,
+                ethers.constants.AddressZero
+            )).to.be.revertedWith("Billing cycle must be > 0");
+        });
     });
 
     describe("updatePlan", function () {
@@ -217,6 +230,13 @@ describe("Subscription Contract", function () {
             await expect(
                 subscriptionContract.connect(owner).updatePlan(0, THIRTY_DAYS_IN_SECS, 0, true, 1000, ethers.constants.AddressZero)
             ).to.be.revertedWith("Price feed address required for USD pricing");
+        });
+
+        it("Reverts when billingCycle is zero", async function () {
+            const { subscriptionContract, owner } = await loadFixture(fixtureWithExistingPlan);
+            await expect(
+                subscriptionContract.connect(owner).updatePlan(0, 0, 0, false, 0, ethers.constants.AddressZero)
+            ).to.be.revertedWith("Billing cycle must be > 0");
         });
 
         async function fixtureWithExistingUsdPlan() {

--- a/test/SubscriptionUpgradeable.ts
+++ b/test/SubscriptionUpgradeable.ts
@@ -120,6 +120,15 @@ describe("SubscriptionUpgradeable additional scenarios", function () {
     return { ...base, cycle, aggregator, usdPrice };
   }
 
+  describe("createPlan", function () {
+    it("reverts when billingCycle is zero", async function () {
+      const { owner, token, proxy } = await loadFixture(deployUpgradeableFixture);
+      await expect(
+        proxy.connect(owner).createPlan(owner.address, token.address, 1, 0, false, 0, ethers.ZeroAddress)
+      ).to.be.revertedWith("Billing cycle must be > 0");
+    });
+  });
+
   describe("subscribeWithPermit", function () {
     it("reverts with expired permit signature", async function () {
       const { owner, user, proxy, token, price } = await loadFixture(permitPlanFixture);
@@ -227,6 +236,13 @@ describe("SubscriptionUpgradeable additional scenarios", function () {
       expect(plan.price).to.equal(newPrice);
       expect(plan.priceFeedAddress).to.equal(ethers.ZeroAddress);
       expect(plan.usdPrice).to.equal(0);
+    });
+
+    it("reverts when billingCycle is zero", async function () {
+      const { proxy, owner } = await loadFixture(tokenPlanFixture);
+      await expect(
+        proxy.connect(owner).updatePlan(PLAN_ID, 0, 0, false, 0, ethers.ZeroAddress)
+      ).to.be.revertedWith("Billing cycle must be > 0");
     });
   });
 });


### PR DESCRIPTION
## Summary
- ensure `billingCycle` is positive in `createPlan` and `updatePlan`
- document requirement in README
- test that zero cycle reverts in both contracts

## Testing
- `npm test` *(fails: unsupported addressable value)*

------
https://chatgpt.com/codex/tasks/task_e_6863c36577548333a51fe95c1be4c6d7