### PR TITLE
Remove unused comment

### DIFF
--- a/test/Subscription.ts
+++ b/test/Subscription.ts
@@ -804,7 +804,7 @@ describe("cancelSubscription", function () {
         const { subscriptionContract, anotherUser } = await loadFixture(fixtureWithActiveSubscriptionForCancel);
         // anotherUser tries to cancel user1's subscription planId, but for their own account
         await expect(subscriptionContract.connect(anotherUser).cancelSubscription(planId))
-            .to.be.revertedWith("Not subscribed to this plan or subscription data mismatch"); // Or "Subscription is already inactive" if it defaults to false
+            .to.be.revertedWith("Not subscribed to this plan or subscription data mismatch");
     });
 
     it("Should prevent cancelling a non-existent plan ID for the user", async function () {


### PR DESCRIPTION
## Summary
- remove outdated comment in Subscription test

## Testing
- `npm test` *(fails: Plugin @nomicfoundation/hardhat-toolbox missing required dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6863d8e74b988333b96b8bafe73a2620