### PR TITLE
Fix outdated test comment

### DIFF
--- a/test/Subscription.ts
+++ b/test/Subscription.ts
@@ -811,7 +811,7 @@ describe("cancelSubscription", function () {
         const { subscriptionContract, user1 } = await loadFixture(fixtureWithActiveSubscriptionForCancel);
         const nonExistentPlanId = 99;
         await expect(subscriptionContract.connect(user1).cancelSubscription(nonExistentPlanId))
-             .to.be.revertedWith("Not subscribed to this plan or subscription data mismatch"); // Or "Subscription is already inactive"
+             .to.be.revertedWith("Not subscribed to this plan or subscription data mismatch");
     });
 
 


### PR DESCRIPTION
## Summary
- update `Subscription` test by removing an obsolete comment

## Testing
- `slither .` *(fails: missing OpenZeppelin imports)*

------
https://chatgpt.com/codex/tasks/task_e_6863daf7378c8333a705dc1599c2092b