### PR TITLE
Add environment variable checks in frontend

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -13,16 +13,23 @@ npm install
 
 ## Environment Variables
 
-Copy `.env.local.example` to `.env.local` and set the required contract address. Optionally provide an RPC URL used when no wallet is available:
+Copy `.env.local.example` to `.env.local` and provide the required variables:
 
 ```bash
 cp .env.local.example .env.local
 
 NEXT_PUBLIC_CONTRACT_ADDRESS=0xYourContractAddress
-# Optional RPC provider used when MetaMask is not available
+# RPC provider used when MetaMask is not available
 NEXT_PUBLIC_RPC_URL=https://sepolia.infura.io/v3/YOUR_KEY
+# GraphQL endpoint for the analytics page
 NEXT_PUBLIC_SUBGRAPH_URL=http://localhost:8000/subgraphs/name/subscription-subgraph/graphql
 ```
+
+Required variables:
+
+- `NEXT_PUBLIC_CONTRACT_ADDRESS` – address of the deployed `Subscription` contract.
+- `NEXT_PUBLIC_RPC_URL` – RPC provider used when no wallet is available.
+- `NEXT_PUBLIC_SUBGRAPH_URL` – GraphQL endpoint for the analytics page.
 
 ## Start
 

--- a/frontend/app/analytics/page.tsx
+++ b/frontend/app/analytics/page.tsx
@@ -19,6 +19,7 @@ interface PaymentData {
 export default function Analytics() {
   const [subs, setSubs] = useState<SubscriptionData[]>([]);
   const [payments, setPayments] = useState<PaymentData[]>([]);
+  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     async function load() {
@@ -31,6 +32,7 @@ export default function Analytics() {
         setPayments(p);
       } catch (err) {
         console.error(err);
+        setError(err instanceof Error ? err.message : String(err));
       }
     }
     load();
@@ -39,6 +41,7 @@ export default function Analytics() {
   return (
     <div>
       <h1>Analytics</h1>
+      {error && <p style={{ color: 'red' }}>{error}</p>}
       <h2>Active Subscriptions</h2>
       <ul>
         {subs.map((s) => (

--- a/frontend/app/manage/page.tsx
+++ b/frontend/app/manage/page.tsx
@@ -6,6 +6,7 @@ import useWallet from '../../lib/useWallet';
 export default function Manage() {
   const { account, connect } = useWallet();
   const [planId, setPlanId] = useState('0');
+  const [error, setError] = useState<string | null>(null);
 
   async function subscribe() {
     try {
@@ -13,6 +14,7 @@ export default function Manage() {
       await contract.subscribe(BigInt(planId));
     } catch (err) {
       console.error(err);
+      setError(err instanceof Error ? err.message : String(err));
     }
   }
 
@@ -22,12 +24,14 @@ export default function Manage() {
       await contract.cancelSubscription(BigInt(planId));
     } catch (err) {
       console.error(err);
+      setError(err instanceof Error ? err.message : String(err));
     }
   }
 
   return (
     <div>
       <h1>Manage Subscription</h1>
+      {error && <p style={{ color: 'red' }}>{error}</p>}
       {!account && <button onClick={connect}>Connect Wallet</button>}
       <div>
         <label>Plan ID: </label>

--- a/frontend/app/payment/page.tsx
+++ b/frontend/app/payment/page.tsx
@@ -7,6 +7,7 @@ export default function Payment() {
   const { account, connect } = useWallet();
   const [planId, setPlanId] = useState('0');
   const [user, setUser] = useState('');
+  const [error, setError] = useState<string | null>(null);
 
   async function trigger() {
     try {
@@ -14,12 +15,14 @@ export default function Payment() {
       await contract.processPayment(user, BigInt(planId));
     } catch (err) {
       console.error(err);
+      setError(err instanceof Error ? err.message : String(err));
     }
   }
 
   return (
     <div>
       <h1>Process Payment</h1>
+      {error && <p style={{ color: 'red' }}>{error}</p>}
       {!account && <button onClick={connect}>Connect Wallet</button>}
       <div>
         <label>User: </label>

--- a/frontend/app/plans/page.tsx
+++ b/frontend/app/plans/page.tsx
@@ -17,6 +17,7 @@ interface Plan {
 export default function Plans() {
   const { account, connect } = useWallet();
   const [plans, setPlans] = useState<Plan[]>([]);
+  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     async function load() {
@@ -31,6 +32,7 @@ export default function Plans() {
         setPlans(list);
       } catch (err) {
         console.error(err);
+        setError(err instanceof Error ? err.message : String(err));
       }
     }
     load();
@@ -39,6 +41,7 @@ export default function Plans() {
   return (
     <div>
       <h1>Available Plans</h1>
+      {error && <p style={{ color: 'red' }}>{error}</p>}
       {!account && <button onClick={connect}>Connect Wallet</button>}
       <ul>
         {plans.map((p, idx) => (

--- a/frontend/lib/contract.ts
+++ b/frontend/lib/contract.ts
@@ -2,6 +2,7 @@ import { ethers } from "ethers";
 import type { ExternalProvider } from "ethers";
 import type { Subscription } from "typechain/contracts/Subscription.sol/Subscription";
 import { Subscription__factory } from "typechain/factories/contracts/Subscription.sol/Subscription__factory";
+import { requireEnv } from "./env";
 
 declare global {
   interface Window {
@@ -10,8 +11,7 @@ declare global {
 }
 
 export async function getContract(): Promise<Subscription> {
-  const address = process.env.NEXT_PUBLIC_CONTRACT_ADDRESS;
-  if (!address) throw new Error("NEXT_PUBLIC_CONTRACT_ADDRESS is not defined");
+  const address = requireEnv("NEXT_PUBLIC_CONTRACT_ADDRESS");
   let signerOrProvider: ethers.Signer | ethers.Provider;
   if (typeof window !== "undefined" && (window as Window).ethereum) {
     const provider = new ethers.BrowserProvider((window as Window).ethereum!);
@@ -19,7 +19,7 @@ export async function getContract(): Promise<Subscription> {
     signerOrProvider = signer;
   } else {
     const rpc = process.env.NEXT_PUBLIC_RPC_URL;
-    if (!rpc) throw new Error("RPC provider not available");
+    if (!rpc) throw new Error("NEXT_PUBLIC_RPC_URL is not defined and no wallet is available");
     signerOrProvider = new ethers.JsonRpcProvider(rpc);
   }
   return Subscription__factory.connect(address, signerOrProvider);

--- a/frontend/lib/env.ts
+++ b/frontend/lib/env.ts
@@ -1,0 +1,7 @@
+export function requireEnv(name: string): string {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`Environment variable ${name} is required`);
+  }
+  return value;
+}

--- a/frontend/lib/subgraph.ts
+++ b/frontend/lib/subgraph.ts
@@ -1,7 +1,8 @@
 import { ApolloClient, InMemoryCache, gql } from '@apollo/client';
+import { requireEnv } from './env';
 
 const client = new ApolloClient({
-  uri: process.env.NEXT_PUBLIC_SUBGRAPH_URL,
+  uri: requireEnv('NEXT_PUBLIC_SUBGRAPH_URL'),
   cache: new InMemoryCache(),
 });
 


### PR DESCRIPTION
## Summary
- throw errors for missing env vars in the frontend
- add `requireEnv` helper
- surface errors in pages when configuration is missing
- document required env vars

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config)*
- `npm test` *(fails: hardhat not found)*

------
https://chatgpt.com/codex/tasks/task_e_68643862d62483338f767f3f0c82c69b