### PR TITLE
Add CLI options to prepare subgraph

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "solhint": "solhint 'contracts/**/*.sol'",
     "typechain": "typechain --target ethers-v6 --out-dir typechain ./artifacts/**/*.json",
     "codegen": "graph codegen subgraph/subgraph.yaml",
-    "build-subgraph": "graph build subgraph/subgraph.yaml",
+    "build-subgraph": "npx --yes ts-node scripts/prepare-subgraph.ts && graph build subgraph/subgraph.local.yaml",
     "coverage": "hardhat coverage",
     "test-subgraph": "graph test",
     "test:e2e": "playwright test"

--- a/scripts/prepare-subgraph.ts
+++ b/scripts/prepare-subgraph.ts
@@ -1,11 +1,37 @@
 import fs from 'fs';
 import path from 'path';
 
-const network = process.env.NETWORK;
-const address = process.env.CONTRACT_ADDRESS;
+function parseArgs() {
+  const result: { network?: string; address?: string } = {};
+  const args = process.argv.slice(2);
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === '--network' && args[i + 1]) {
+      result.network = args[i + 1];
+      i++;
+    } else if (arg.startsWith('--network=')) {
+      result.network = arg.split('=')[1];
+    } else if (arg === '--address' && args[i + 1]) {
+      result.address = args[i + 1];
+      i++;
+    } else if (arg.startsWith('--address=')) {
+      result.address = arg.split('=')[1];
+    }
+  }
+
+  return result;
+}
+
+const { network: networkArg, address: addressArg } = parseArgs();
+
+const network = networkArg || process.env.NETWORK;
+const address = addressArg || process.env.CONTRACT_ADDRESS;
 
 if (!network || !address) {
-  console.error('NETWORK and CONTRACT_ADDRESS env vars must be set');
+  console.error(
+    'NETWORK/--network and CONTRACT_ADDRESS/--address must be provided'
+  );
   process.exit(1);
 }
 


### PR DESCRIPTION
## Summary
- add CLI argument support to `scripts/prepare-subgraph.ts`
- run `prepare-subgraph` automatically when building the subgraph

## Testing
- `npx --yes ts-node scripts/prepare-subgraph.ts --network test --address 0x1234567890` *(fails: Unable to compile TypeScript)*

------
https://chatgpt.com/codex/tasks/task_e_68643867dd388333a123b84189bc9ebd