### PR TITLE
Enhance upgrade e2e test

### DIFF
--- a/e2e/upgrade-flow.spec.ts
+++ b/e2e/upgrade-flow.spec.ts
@@ -183,6 +183,23 @@ test('upgrade flow', async ({ page }) => {
     amount: ethers.parseUnits('10', 18).toString(),
     newNextPaymentDate: finalSub.nextPaymentDate.toString(),
   });
+
+  // verify events before and after upgrade are returned by the subgraph
+  const res = await fetch(SUBGRAPH_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      query:
+        '{ subscriptions { id planId } payments { id planId } }',
+    }),
+  });
+  const json = await res.json();
+  expect(json.data.subscriptions.length).toBe(1);
+  expect(json.data.subscriptions[0].id).toBe(`${user}-0`);
+  expect(json.data.payments.length).toBe(1);
+  expect(json.data.payments[0].id).toBe('1');
+
+  expect(await upgraded.version()).toBe('v2');
 });
 
 test('analytics page shows subgraph data', async ({ page }) => {


### PR DESCRIPTION
## Summary
- verify subgraph can query events before and after upgrade
- assert payments use the upgraded ABI via `version()` check

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm run test:e2e` *(fails: playwright not found)*

------
https://chatgpt.com/codex/tasks/task_e_68643868bd9c8333a219eea01da8a12f