### PR TITLE
Improve UI feedback for contract operations

### DIFF
--- a/frontend/app/analytics/page.tsx
+++ b/frontend/app/analytics/page.tsx
@@ -19,9 +19,11 @@ interface PaymentData {
 export default function Analytics() {
   const [subs, setSubs] = useState<SubscriptionData[]>([]);
   const [payments, setPayments] = useState<PaymentData[]>([]);
+  const [loading, setLoading] = useState(false);
 
   useEffect(() => {
     async function load() {
+      setLoading(true);
       try {
         const [s, p] = await Promise.all([
           getActiveSubscriptions(),
@@ -29,8 +31,11 @@ export default function Analytics() {
         ]);
         setSubs(s);
         setPayments(p);
-      } catch (err) {
+      } catch (err: any) {
         console.error(err);
+        alert(err?.message || 'Failed to load analytics');
+      } finally {
+        setLoading(false);
       }
     }
     load();
@@ -39,22 +44,28 @@ export default function Analytics() {
   return (
     <div>
       <h1>Analytics</h1>
-      <h2>Active Subscriptions</h2>
-      <ul>
-        {subs.map((s) => (
-          <li key={s.id}>
-            {s.user} plan {s.planId} next payment {s.nextPaymentDate}
-          </li>
-        ))}
-      </ul>
-      <h2>Payments</h2>
-      <ul>
-        {payments.map((p) => (
-          <li key={p.id}>
-            {p.user} plan {p.planId} amount {p.amount}
-          </li>
-        ))}
-      </ul>
+      {loading ? (
+        <p>Loading analytics...</p>
+      ) : (
+        <>
+          <h2>Active Subscriptions</h2>
+          <ul>
+            {subs.map((s) => (
+              <li key={s.id}>
+                {s.user} plan {s.planId} next payment {s.nextPaymentDate}
+              </li>
+            ))}
+          </ul>
+          <h2>Payments</h2>
+          <ul>
+            {payments.map((p) => (
+              <li key={p.id}>
+                {p.user} plan {p.planId} amount {p.amount}
+              </li>
+            ))}
+          </ul>
+        </>
+      )}
     </div>
   );
 }

--- a/frontend/app/manage/page.tsx
+++ b/frontend/app/manage/page.tsx
@@ -6,22 +6,36 @@ import useWallet from '../../lib/useWallet';
 export default function Manage() {
   const { account, connect } = useWallet();
   const [planId, setPlanId] = useState('0');
+  const [loadingSub, setLoadingSub] = useState(false);
+  const [loadingCancel, setLoadingCancel] = useState(false);
 
   async function subscribe() {
+    setLoadingSub(true);
     try {
       const contract = await getContract();
-      await contract.subscribe(BigInt(planId));
-    } catch (err) {
+      const tx = await contract.subscribe(BigInt(planId));
+      await tx.wait();
+      alert(`Subscribed. Tx: ${tx.hash}`);
+    } catch (err: any) {
       console.error(err);
+      alert(err?.message || 'Transaction failed');
+    } finally {
+      setLoadingSub(false);
     }
   }
 
   async function cancel() {
+    setLoadingCancel(true);
     try {
       const contract = await getContract();
-      await contract.cancelSubscription(BigInt(planId));
-    } catch (err) {
+      const tx = await contract.cancelSubscription(BigInt(planId));
+      await tx.wait();
+      alert(`Subscription cancelled. Tx: ${tx.hash}`);
+    } catch (err: any) {
       console.error(err);
+      alert(err?.message || 'Transaction failed');
+    } finally {
+      setLoadingCancel(false);
     }
   }
 
@@ -33,8 +47,12 @@ export default function Manage() {
         <label>Plan ID: </label>
         <input value={planId} onChange={e => setPlanId(e.target.value)} />
       </div>
-      <button onClick={subscribe}>Subscribe</button>
-      <button onClick={cancel}>Cancel</button>
+      <button onClick={subscribe} disabled={loadingSub}>
+        {loadingSub ? 'Subscribing...' : 'Subscribe'}
+      </button>
+      <button onClick={cancel} disabled={loadingCancel}>
+        {loadingCancel ? 'Cancelling...' : 'Cancel'}
+      </button>
     </div>
   );
 }

--- a/frontend/app/payment/page.tsx
+++ b/frontend/app/payment/page.tsx
@@ -7,13 +7,20 @@ export default function Payment() {
   const { account, connect } = useWallet();
   const [planId, setPlanId] = useState('0');
   const [user, setUser] = useState('');
+  const [loading, setLoading] = useState(false);
 
   async function trigger() {
+    setLoading(true);
     try {
       const contract = await getContract();
-      await contract.processPayment(user, BigInt(planId));
-    } catch (err) {
+      const tx = await contract.processPayment(user, BigInt(planId));
+      await tx.wait();
+      alert(`Payment successful. Tx: ${tx.hash}`);
+    } catch (err: any) {
       console.error(err);
+      alert(err?.message || 'Transaction failed');
+    } finally {
+      setLoading(false);
     }
   }
 
@@ -29,7 +36,9 @@ export default function Payment() {
         <label>Plan ID: </label>
         <input value={planId} onChange={e => setPlanId(e.target.value)} />
       </div>
-      <button onClick={trigger}>Process</button>
+      <button onClick={trigger} disabled={loading}>
+        {loading ? 'Processing...' : 'Process'}
+      </button>
     </div>
   );
 }

--- a/frontend/app/plans/page.tsx
+++ b/frontend/app/plans/page.tsx
@@ -17,9 +17,11 @@ interface Plan {
 export default function Plans() {
   const { account, connect } = useWallet();
   const [plans, setPlans] = useState<Plan[]>([]);
+  const [loading, setLoading] = useState(false);
 
   useEffect(() => {
     async function load() {
+      setLoading(true);
       try {
         const contract = await getContract();
         const nextId: bigint = await contract.nextPlanId();
@@ -29,8 +31,11 @@ export default function Plans() {
           list.push(plan as Plan);
         }
         setPlans(list);
-      } catch (err) {
+      } catch (err: any) {
         console.error(err);
+        alert(err?.message || 'Failed to load plans');
+      } finally {
+        setLoading(false);
       }
     }
     load();
@@ -40,13 +45,17 @@ export default function Plans() {
     <div>
       <h1>Available Plans</h1>
       {!account && <button onClick={connect}>Connect Wallet</button>}
-      <ul>
-        {plans.map((p, idx) => (
-          <li key={idx}>
-            Plan {idx}: token {p.token} price {p.price.toString()} billing {p.billingCycle.toString()}s
-          </li>
-        ))}
-      </ul>
+      {loading ? (
+        <p>Loading plans...</p>
+      ) : (
+        <ul>
+          {plans.map((p, idx) => (
+            <li key={idx}>
+              Plan {idx}: token {p.token} price {p.price.toString()} billing {p.billingCycle.toString()}s
+            </li>
+          ))}
+        </ul>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- show transaction hashes and errors in `/payment`
- provide loading states and transaction alerts for `/manage`
- add loading/alert handling when listing `/plans`

## Testing
- `npm test` *(fails: hardhat not found)*
- `npm run lint` *(fails: ESLint config error)*

------
https://chatgpt.com/codex/tasks/task_e_6864386937508333939327207641e108