### PR TITLE
Update docs for local Graph node and headless Playwright tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,13 +34,18 @@ compilation.
 
 ## E2E-Tests
 
-Die Playwright-Tests befinden sich im Ordner `e2e/` und lassen sich mit
+Die Playwright-Tests befinden sich im Ordner `e2e/`. Sie laufen standardmäßig
+im Headless-Modus. Starte sie mit:
 
 ```bash
 npm run test:e2e
 ```
 
-ausführen.
+Dies ruft `playwright test` auf und öffnet keinen Browser. Die Tests starten
+einen lokalen Hardhat-Knoten sowie den Next.js-Server und setzen dabei die
+Umgebungsvariablen `NEXT_PUBLIC_CONTRACT_ADDRESS`, `NEXT_PUBLIC_RPC_URL` und
+`NEXT_PUBLIC_SUBGRAPH_URL` automatisch. Weitere Einstellungen sind nicht
+erforderlich.
 
 ## Deployment
 

--- a/docs/usage-examples.md
+++ b/docs/usage-examples.md
@@ -70,7 +70,24 @@ query the data, follow these steps:
    ```
 
 2. Install `graph-node` using the [official packages](https://github.com/graphprotocol/graph-node/releases)
-   or by building it from source. Start the node locally, for example:
+   or by building it from source. `graph-node` requires a running PostgreSQL
+   database and an IPFS daemon. Create a database called `graph-node` and ensure
+   IPFS is available on `localhost:5001`.
+
+   A quick way to start the node is using Docker:
+
+   ```bash
+   docker run -it --rm -p 8000:8000 -p 8020:8020 \
+     -e postgres_host=host.docker.internal \
+     -e postgres_user=graph \
+     -e postgres_pass=password \
+     -e postgres_db=graph-node \
+     -e ethereum=NETWORK:http://host.docker.internal:8545 \
+     -e ipfs=host.docker.internal:5001 \
+     graphprotocol/graph-node:latest
+   ```
+
+   If you have the binary installed locally, start it as follows:
 
    ```bash
    graph-node \


### PR DESCRIPTION
## Summary
- explain how to start a local Graph node with Docker
- show how to run Playwright e2e tests headlessly and mention the environment variables

## Testing
- `npm test` *(fails: 56 failing)*

------
https://chatgpt.com/codex/tasks/task_e_68643869b9c08333a889f580eb34b691