### PR TITLE
Add env variable checks in frontend contract

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -25,7 +25,7 @@ NEXT_PUBLIC_RPC_URL=https://sepolia.infura.io/v3/YOUR_KEY
 NEXT_PUBLIC_SUBGRAPH_URL=http://localhost:8000/subgraphs/name/subscription-subgraph/graphql
 ```
 
-Required variables:
+These values are required and the app will throw an error on startup if any are missing (see `lib/env.ts`):
 
 - `NEXT_PUBLIC_CONTRACT_ADDRESS` – address of the deployed `Subscription` contract.
 - `NEXT_PUBLIC_RPC_URL` – RPC provider used when no wallet is available.

--- a/frontend/lib/contract.ts
+++ b/frontend/lib/contract.ts
@@ -18,8 +18,7 @@ export async function getContract(): Promise<Subscription> {
     const signer = await provider.getSigner();
     signerOrProvider = signer;
   } else {
-    const rpc = process.env.NEXT_PUBLIC_RPC_URL;
-    if (!rpc) throw new Error("NEXT_PUBLIC_RPC_URL is not defined and no wallet is available");
+    const rpc = requireEnv("NEXT_PUBLIC_RPC_URL");
     signerOrProvider = new ethers.JsonRpcProvider(rpc);
   }
   return Subscription__factory.connect(address, signerOrProvider);


### PR DESCRIPTION
## Summary
- use `requireEnv()` for RPC address in frontend contract
- clarify README about required environment variables

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm test` *(fails: hardhat not found)*
- `npm install` *(fails: dependency conflict)*

------
https://chatgpt.com/codex/tasks/task_e_68643fd3e5488333ad2edec85eb86e32