### PR TITLE
Add CI workflow caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ jobs:
         with:
           node-version: '18'
           cache: 'npm'
+          cache-dependency-path: package-lock.json
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
## Summary
- cache Node dependencies in CI to speed up runs

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm test` *(fails: hardhat not found)*
- `npm run coverage` *(fails: hardhat not found)*
- `slither .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68643fd526f48333a24e5d675a3d7c88