### PR TITLE
Add network configs for Sepolia/Mainnet

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,21 @@ private keys from `.env` as well:
 - `MAINNET_RPC_URL`
 - `MAINNET_PRIVATE_KEY`
 
+Your `hardhat.config.ts` should include network settings that load these values:
+
+```ts
+networks: {
+  sepolia: {
+    url: process.env.SEPOLIA_RPC_URL || "",
+    accounts: process.env.SEPOLIA_PRIVATE_KEY ? [process.env.SEPOLIA_PRIVATE_KEY] : [],
+  },
+  mainnet: {
+    url: process.env.MAINNET_RPC_URL || "",
+    accounts: process.env.MAINNET_PRIVATE_KEY ? [process.env.MAINNET_PRIVATE_KEY] : [],
+  },
+}
+```
+
 Example deployment to a testnet network configured in `hardhat.config.ts`:
 
 ```bash

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -30,6 +30,7 @@ const config: HardhatUserConfig = {
     enabled: true,
   },
   networks: {
+    // Example settings reading RPC URLs and keys from `.env`
     sepolia: {
       url: process.env.SEPOLIA_RPC_URL || "",
       accounts: process.env.SEPOLIA_PRIVATE_KEY ? [process.env.SEPOLIA_PRIVATE_KEY] : [],


### PR DESCRIPTION
## Summary
- document the Sepolia and Mainnet network options in the README
- add a comment in `hardhat.config.ts` explaining network config example

## Testing
- `npm test` *(fails: 59 failing)*

------
https://chatgpt.com/codex/tasks/task_e_68643fd6dae08333be51087f5b3d6914