### PR TITLE
Add version check post-upgrade

### DIFF
--- a/e2e/upgrade-flow.spec.ts
+++ b/e2e/upgrade-flow.spec.ts
@@ -174,6 +174,9 @@ test('upgrade flow', async ({ page }) => {
     return sub.nextPaymentDate > before;
   }).toBe(true);
 
+  // confirm the proxy now exposes the upgraded ABI
+  expect(await upgraded.version()).toBe('v2');
+
   const finalSub = await upgraded.userSubscriptions(user, 0);
   subgraphData.subscriptions[0].nextPaymentDate = finalSub.nextPaymentDate.toString();
   subgraphData.payments.push({


### PR DESCRIPTION
## Summary
- verify upgraded ABI is used after processing payment

## Testing
- `npm run test:e2e` *(fails: TransparentUpgradeableProxy.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68643fdaf20c8333bd0d7eb6ad903f3e