### PR TITLE
Implement permit-based subscription

### DIFF
--- a/frontend/app/manage/page.tsx
+++ b/frontend/app/manage/page.tsx
@@ -1,11 +1,17 @@
 'use client';
 import { useState } from 'react';
-import { getContract } from '../../lib/contract';
+import { ethers } from 'ethers';
+import { getContract, subscribeWithPermit } from '../../lib/contract';
+import { AggregatorV3Interface__factory } from 'typechain/factories/contracts/interfaces/AggregatorV3Interface__factory';
 import useWallet from '../../lib/useWallet';
 
 export default function Manage() {
   const { account, connect } = useWallet();
   const [planId, setPlanId] = useState('0');
+  const [deadline, setDeadline] = useState('');
+  const [v, setV] = useState('');
+  const [r, setR] = useState('');
+  const [s, setS] = useState('');
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
 
@@ -43,6 +49,77 @@ export default function Manage() {
     }
   }
 
+  async function requestPermit() {
+    if (!account) return alert('Connect Wallet first');
+    setLoading(true);
+    setError(null);
+    try {
+      const contract = await getContract();
+      const plan = await contract.plans(BigInt(planId));
+      const provider = new ethers.BrowserProvider((window as any).ethereum);
+      const signer = await provider.getSigner();
+      const token = new ethers.Contract(
+        plan.token,
+        ['function name() view returns (string)', 'function nonces(address) view returns (uint256)'],
+        provider
+      );
+      const tokenName: string = await token.name();
+      const nonce: bigint = await token.nonces(account);
+      const chainId = await signer.getChainId();
+      let amount: bigint = plan.price;
+      if (plan.priceInUsd) {
+        const feed = AggregatorV3Interface__factory.connect(plan.priceFeedAddress, provider);
+        const [, price,,] = await feed.latestRoundData();
+        const decimals = await feed.decimals();
+        amount = (plan.usdPrice * (10n ** plan.tokenDecimals) * (10n ** BigInt(decimals))) / (100n * BigInt(price));
+      }
+      const domain = { name: tokenName, version: '1', chainId, verifyingContract: plan.token };
+      const types = {
+        Permit: [
+          { name: 'owner', type: 'address' },
+          { name: 'spender', type: 'address' },
+          { name: 'value', type: 'uint256' },
+          { name: 'nonce', type: 'uint256' },
+          { name: 'deadline', type: 'uint256' },
+        ],
+      } as const;
+      const values = { owner: account, spender: contract.target, value: amount, nonce, deadline: BigInt(deadline) };
+      const signature = await signer.signTypedData(domain, types, values);
+      const sig = ethers.Signature.from(signature);
+      setV(sig.v.toString());
+      setR(sig.r);
+      setS(sig.s);
+    } catch (err) {
+      console.error(err);
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function subscribePermit() {
+    setLoading(true);
+    setError(null);
+    try {
+      const tx = await subscribeWithPermit(
+        BigInt(planId),
+        BigInt(deadline),
+        Number(v),
+        r as `0x${string}`,
+        s as `0x${string}`
+      );
+      await tx.wait();
+      alert(`Subscribed with permit! Tx: ${tx.hash}`);
+    } catch (err) {
+      console.error(err);
+      const message = err instanceof Error ? err.message : String(err);
+      setError(message);
+      alert(`Subscription failed: ${message}`);
+    } finally {
+      setLoading(false);
+    }
+  }
+
   return (
     <div>
       <h1>Manage Subscription</h1>
@@ -53,6 +130,24 @@ export default function Manage() {
         <label>Plan ID: </label>
         <input value={planId} onChange={e => setPlanId(e.target.value)} />
       </div>
+      <div>
+        <label>Deadline (unix secs): </label>
+        <input value={deadline} onChange={e => setDeadline(e.target.value)} />
+      </div>
+      <div>
+        <label>v: </label>
+        <input value={v} onChange={e => setV(e.target.value)} />
+      </div>
+      <div>
+        <label>r: </label>
+        <input value={r} onChange={e => setR(e.target.value)} />
+      </div>
+      <div>
+        <label>s: </label>
+        <input value={s} onChange={e => setS(e.target.value)} />
+      </div>
+      <button onClick={requestPermit} disabled={loading || !account}>Get Permit Signature</button>
+      <button onClick={subscribePermit} disabled={loading}>Subscribe with Permit</button>
       <button onClick={subscribe} disabled={loading}>Subscribe</button>
       <button onClick={cancel} disabled={loading}>Cancel</button>
     </div>

--- a/frontend/lib/contract.ts
+++ b/frontend/lib/contract.ts
@@ -23,3 +23,14 @@ export async function getContract(): Promise<Subscription> {
   }
   return Subscription__factory.connect(address, signerOrProvider);
 }
+
+export async function subscribeWithPermit(
+  planId: bigint,
+  deadline: bigint,
+  v: number,
+  r: string,
+  s: string
+) {
+  const contract = await getContract();
+  return contract.subscribeWithPermit(planId, deadline, v, r, s);
+}


### PR DESCRIPTION
## Summary
- allow signing permit and using it to subscribe
- wrap subscribeWithPermit in contract helper

## Testing
- `npm test` *(fails: Cannot find module 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_68652eb2e9e88333a3c2487b67ce8aaa