### PR TITLE
Add env validation helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,9 @@ Two deployment scripts are provided under `scripts/`.
 - **Testnet** – `scripts/deploy-testnet.ts`
 - **Mainnet** – `scripts/deploy-mainnet.ts`
 
+Before deploying, each script runs `scripts/check-env.ts` to verify that all
+variables in `.env.example` are set.
+
 Both scripts require the following environment variables:
 
 - `MERCHANT_ADDRESS`

--- a/scripts/check-env.ts
+++ b/scripts/check-env.ts
@@ -1,0 +1,17 @@
+import fs from 'fs';
+import path from 'path';
+
+export function checkEnv(): void {
+  const envExamplePath = path.resolve(__dirname, '..', '.env.example');
+  const lines = fs.readFileSync(envExamplePath, 'utf-8').split(/\r?\n/);
+  const keys = lines
+    .map((line) => line.trim())
+    .filter((line) => line && !line.startsWith('#'))
+    .map((line) => line.split('=')[0]);
+  const missing = keys.filter((key) => !process.env[key]);
+  if (missing.length > 0) {
+    throw new Error(
+      `Missing required environment variables: ${missing.join(', ')}`,
+    );
+  }
+}

--- a/scripts/deploy-mainnet.ts
+++ b/scripts/deploy-mainnet.ts
@@ -1,6 +1,8 @@
 import { ethers, upgrades } from "hardhat";
+import { checkEnv } from "./check-env";
 
 async function main() {
+  checkEnv();
   const merchant = process.env.MERCHANT_ADDRESS || ethers.constants.AddressZero;
   const token = process.env.TOKEN_ADDRESS || ethers.constants.AddressZero;
   const priceFeed = process.env.PRICE_FEED || ethers.constants.AddressZero;

--- a/scripts/deploy-testnet.ts
+++ b/scripts/deploy-testnet.ts
@@ -1,6 +1,8 @@
 import { ethers, upgrades } from "hardhat";
+import { checkEnv } from "./check-env";
 
 async function main() {
+  checkEnv();
   const merchant = process.env.MERCHANT_ADDRESS || ethers.constants.AddressZero;
   const token = process.env.TOKEN_ADDRESS || ethers.constants.AddressZero;
   const priceFeed = process.env.PRICE_FEED || ethers.constants.AddressZero;


### PR DESCRIPTION
## Summary
- add `check-env.ts` helper for deployment scripts
- import helper in deployment scripts
- update README deployment instructions

## Testing
- `npm test` *(fails: hardhat not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866f7b5fb0c833390a4cdcdfe9c6b4b