### PR TITLE
Add subgraph integration test

### DIFF
--- a/subgraph/tests/integration.test.ts
+++ b/subgraph/tests/integration.test.ts
@@ -1,0 +1,165 @@
+import { spawn, spawnSync, execSync, ChildProcess } from 'child_process';
+import { expect } from 'chai';
+import fetch from 'node-fetch';
+import fs from 'fs';
+import path from 'path';
+import { ethers } from 'ethers';
+
+// Utility waiting for a URL to respond with 200
+async function waitFor(
+  url: string,
+  attempts = 60,
+  delayMs = 1000,
+): Promise<void> {
+  for (let i = 0; i < attempts; i++) {
+    try {
+      const res = await fetch(url);
+      if (res.ok) return;
+    } catch {}
+    await new Promise((r) => setTimeout(r, delayMs));
+  }
+  throw new Error(`Timeout waiting for ${url}`);
+}
+
+describe('Subgraph integration', function () {
+  this.timeout(300000); // 5 minutes
+
+  let hardhat: ChildProcess;
+  let graphNode: ChildProcess;
+
+  before(async function () {
+    try {
+      execSync('docker --version', { stdio: 'ignore' });
+    } catch {
+      this.skip();
+      return;
+    }
+
+    hardhat = spawn('npx', ['hardhat', 'node'], { stdio: 'inherit' });
+    await new Promise((r) => setTimeout(r, 4000));
+    spawnSync('npx', ['hardhat', 'compile'], { stdio: 'inherit' });
+
+    graphNode = spawn(
+      'docker',
+      [
+        'run',
+        '--rm',
+        '-p',
+        '8000:8000',
+        '-p',
+        '8020:8020',
+        '-e',
+        'postgres_host=host.docker.internal',
+        '-e',
+        'postgres_user=graph',
+        '-e',
+        'postgres_pass=password',
+        '-e',
+        'postgres_db=graph-node',
+        '-e',
+        'ethereum=hardhat:http://host.docker.internal:8545',
+        '-e',
+        'ipfs=host.docker.internal:5001',
+        'graphprotocol/graph-node:latest',
+      ],
+      { stdio: 'inherit' },
+    );
+
+    await waitFor('http://localhost:8000/health');
+  });
+
+  after(async () => {
+    if (graphNode) graphNode.kill('SIGINT');
+    if (hardhat) hardhat.kill('SIGINT');
+  });
+
+  it('indexes events from Subscription', async () => {
+    const provider = new ethers.JsonRpcProvider('http://127.0.0.1:8545');
+    const [owner, user] = await provider.listAccounts();
+    const ownerSigner = provider.getSigner(owner);
+    const userSigner = provider.getSigner(user);
+
+    const tokenJson = JSON.parse(
+      fs.readFileSync(
+        path.join('artifacts', 'contracts', 'MockToken.sol', 'MockToken.json'),
+        'utf8',
+      ),
+    );
+    const tokenFactory = new ethers.ContractFactory(
+      tokenJson.abi,
+      tokenJson.bytecode,
+      ownerSigner,
+    );
+    const token = await tokenFactory.deploy('Mock', 'MOCK', 18);
+    await token.waitForDeployment();
+    await token.mint(user, ethers.parseUnits('100', 18));
+
+    const subJson = JSON.parse(
+      fs.readFileSync(
+        path.join(
+          'artifacts',
+          'contracts',
+          'Subscription.sol',
+          'Subscription.json',
+        ),
+        'utf8',
+      ),
+    );
+    const subFactory = new ethers.ContractFactory(
+      subJson.abi,
+      subJson.bytecode,
+      ownerSigner,
+    );
+    const subscription = await subFactory.deploy();
+    await subscription.waitForDeployment();
+
+    await token
+      .connect(userSigner)
+      .approve(subscription.getAddress(), ethers.parseUnits('100', 18));
+    await subscription
+      .connect(ownerSigner)
+      .createPlan(
+        owner,
+        token.getAddress(),
+        ethers.parseUnits('1', 18),
+        60,
+        false,
+        0,
+        ethers.ZeroAddress,
+      );
+    await subscription.connect(userSigner).subscribe(0);
+
+    process.env.NETWORK = 'hardhat';
+    process.env.CONTRACT_ADDRESS = await subscription.getAddress();
+    spawnSync('npm', ['run', 'build-subgraph'], { stdio: 'inherit' });
+
+    spawnSync(
+      'npx',
+      [
+        'graph',
+        'deploy',
+        '--node',
+        'http://localhost:8020/',
+        '--ipfs',
+        'http://localhost:5001/',
+        'subscription-subgraph',
+        'subgraph/subgraph.local.yaml',
+      ],
+      { stdio: 'inherit' },
+    );
+
+    // wait for indexing
+    await new Promise((r) => setTimeout(r, 5000));
+
+    const res = await fetch(
+      'http://localhost:8000/subgraphs/name/subscription-subgraph/graphql',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ query: '{ subscriptions { id } }' }),
+      },
+    );
+    const json = await res.json();
+    expect(json.data.subscriptions.length).to.equal(1);
+  });
+});


### PR DESCRIPTION
## Summary
- add a Docker-based integration test for the subgraph

## Testing
- `npx hardhat test subgraph/tests/integration.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_6866f7b5e5248333912f8e36ac40e75a