### PR TITLE
Add gas reporter to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: ["main"]
+    branches: ['main']
   pull_request:
-    branches: ["main"]
+    branches: ['main']
 
 jobs:
   build:
@@ -40,6 +40,15 @@ jobs:
 
       - name: Run coverage
         run: npm run coverage
+
+      - name: Run gas report
+        run: npm run gas
+
+      - name: Upload gas report
+        uses: actions/upload-artifact@v4
+        with:
+          name: gas-report
+          path: gas-report.txt
 
       - name: Run Slither
         run: slither .

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -41,6 +41,7 @@ The owner can adjust an existing plan using `updatePlan`. It checks that the pla
 ### Reentrancy Protection
 
 Both versions of the contract inherit from `ReentrancyGuard`. Functions that transfer tokens such as `subscribe`, `processPayment` and `cancelSubscription` are marked `nonReentrant` to block malicious nested calls.
+
 ### Security Considerations
 
 The contract follows the checks-effects-interactions pattern. State updates now occur **before** external token transfers to minimize reentrancy risk. Each token transfer additionally checks the spender's allowance to prevent unintended transfers.
@@ -49,3 +50,7 @@ The contract follows the checks-effects-interactions pattern. State updates now 
 `processPayment` additionally checks that the subscriber address passed in
 matches the stored subscription to stop merchants from charging arbitrary
 users even if they have approved allowances.
+
+### Gas Report
+
+The CI workflow runs `npm run gas` to generate `gas-report.txt`. Each row of the report lists a contract with its minimum, maximum and average gas usage during tests. Use the report to monitor how updates affect deployment and execution costs.

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -1,13 +1,13 @@
-import { HardhatUserConfig } from "hardhat/config";
-import "@nomicfoundation/hardhat-toolbox";
-import "@nomicfoundation/hardhat-verify";
-import "@openzeppelin/hardhat-upgrades";
-import "@typechain/hardhat";
-import "hardhat-gas-reporter";
+import { HardhatUserConfig } from 'hardhat/config';
+import '@nomicfoundation/hardhat-toolbox';
+import '@nomicfoundation/hardhat-verify';
+import '@openzeppelin/hardhat-upgrades';
+import '@typechain/hardhat';
+import 'hardhat-gas-reporter';
 
-import path from "path";
-import * as dotenv from "dotenv";
-import "./tasks/upgrade";
+import path from 'path';
+import * as dotenv from 'dotenv';
+import './tasks/upgrade';
 
 dotenv.config();
 
@@ -15,30 +15,36 @@ const config: HardhatUserConfig = {
   solidity: {
     compilers: [
       {
-        version: "0.8.26",
-        path: path.resolve(__dirname, "node_modules/solc/soljson.js"),
+        version: '0.8.26',
+        path: path.resolve(__dirname, 'node_modules/solc/soljson.js'),
       },
     ],
   },
   typechain: {
-    outDir: "typechain",
-    target: "ethers-v6",
+    outDir: 'typechain',
+    target: 'ethers-v6',
   },
   etherscan: {
-    apiKey: process.env.ETHERSCAN_API_KEY || "",
+    apiKey: process.env.ETHERSCAN_API_KEY || '',
   },
   gasReporter: {
     enabled: true,
+    outputFile: 'gas-report.txt',
+    noColors: true,
   },
   networks: {
     // Example settings reading RPC URLs and keys from `.env`
     sepolia: {
-      url: process.env.SEPOLIA_RPC_URL || "",
-      accounts: process.env.SEPOLIA_PRIVATE_KEY ? [process.env.SEPOLIA_PRIVATE_KEY] : [],
+      url: process.env.SEPOLIA_RPC_URL || '',
+      accounts: process.env.SEPOLIA_PRIVATE_KEY
+        ? [process.env.SEPOLIA_PRIVATE_KEY]
+        : [],
     },
     mainnet: {
-      url: process.env.MAINNET_RPC_URL || "",
-      accounts: process.env.MAINNET_PRIVATE_KEY ? [process.env.MAINNET_PRIVATE_KEY] : [],
+      url: process.env.MAINNET_RPC_URL || '',
+      accounts: process.env.MAINNET_PRIVATE_KEY
+        ? [process.env.MAINNET_PRIVATE_KEY]
+        : [],
     },
   },
 };


### PR DESCRIPTION
## Summary
- run `npm run gas` as part of CI
- upload the gas report artifact
- output gas report to `gas-report.txt`
- document how to read the gas report

## Testing
- `npm run lint` *(fails: ESLint plugin missing)*
- `npm test` *(fails: hardhat not found because dependencies were removed)*
- `npm run gas` *(fails: hardhat not found because dependencies were removed)*

------
https://chatgpt.com/codex/tasks/task_e_6867a68692908333b00bf48c65c37c0f