### PR TITLE
Add client-side validation helpers and tests

### DIFF
--- a/frontend/__tests__/CreatePlan.test.tsx
+++ b/frontend/__tests__/CreatePlan.test.tsx
@@ -19,3 +19,22 @@ test('shows validation errors', async () => {
   await userEvent.click(screen.getByText('Create'));
   expect(screen.getByText(/Token address invalid/)).toBeInTheDocument();
 });
+
+test('validates merchant address', async () => {
+  render(<Wrapper />);
+  await userEvent.type(screen.getByLabelText('Merchant'), 'foo');
+  await userEvent.type(screen.getByLabelText('Token'), '0x1111111111111111111111111111111111111111');
+  await userEvent.type(screen.getByLabelText('Billing (seconds)'), '1');
+  await userEvent.type(screen.getByLabelText('Token Price'), '1');
+  await userEvent.click(screen.getByText('Create'));
+  expect(screen.getByText(/Merchant address invalid/)).toBeInTheDocument();
+});
+
+test('validates billing cycle', async () => {
+  render(<Wrapper />);
+  await userEvent.type(screen.getByLabelText('Token'), '0x1111111111111111111111111111111111111111');
+  await userEvent.type(screen.getByLabelText('Billing (seconds)'), '0');
+  await userEvent.type(screen.getByLabelText('Token Price'), '1');
+  await userEvent.click(screen.getByText('Create'));
+  expect(screen.getByText(/Billing cycle must be > 0/)).toBeInTheDocument();
+});

--- a/frontend/app/plans/create/page.tsx
+++ b/frontend/app/plans/create/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 import { useState } from 'react';
 import { createPlan } from '../../../lib/contract';
+import { validateAddress, validatePositiveInt } from '../../../lib/validation';
 import useWallet from '../../../lib/useWallet';
 import { useStore } from '../../../lib/store';
 
@@ -21,13 +22,14 @@ export default function CreatePlan() {
     setLoading(true);
     setError(null);
     try {
-      if (!/^0x[0-9a-fA-F]{40}$/.test(token)) throw new Error('Token address invalid');
-      if (!billing || Number(billing) <= 0) throw new Error('Billing cycle > 0');
+      if (merchant) validateAddress(merchant, 'Merchant');
+      validateAddress(token, 'Token');
+      validatePositiveInt(billing, 'Billing cycle');
       if (priceInUsd) {
-        if (!/^[0-9]+$/.test(usdPrice)) throw new Error('USD price required');
-        if (!/^0x[0-9a-fA-F]{40}$/.test(feed)) throw new Error('Price feed required');
+        validatePositiveInt(usdPrice, 'USD price');
+        validateAddress(feed, 'Price feed');
       } else {
-        if (!/^[0-9]+$/.test(price)) throw new Error('Token price required');
+        validatePositiveInt(price, 'Token price');
       }
       const tx = await createPlan(
         merchant || account || '0x0000000000000000000000000000000000000000',

--- a/frontend/app/plans/update/page.tsx
+++ b/frontend/app/plans/update/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 import { useState } from 'react';
 import { updatePlan } from '../../../lib/contract';
+import { validateAddress, validatePositiveInt } from '../../../lib/validation';
 import useWallet from '../../../lib/useWallet';
 import { useStore } from '../../../lib/store';
 
@@ -21,7 +22,14 @@ export default function UpdatePlan() {
     setError(null);
     try {
       if (!planId) throw new Error('plan id required');
-      if (!billing || Number(billing) <= 0) throw new Error('billing cycle > 0');
+      validatePositiveInt(planId, 'plan id');
+      validatePositiveInt(billing, 'billing cycle');
+      if (priceInUsd) {
+        validatePositiveInt(usdPrice, 'USD price');
+        validateAddress(feed, 'Price feed');
+      } else {
+        validatePositiveInt(price, 'Token price');
+      }
       const tx = await updatePlan(
         BigInt(planId),
         BigInt(billing),

--- a/frontend/lib/validation.ts
+++ b/frontend/lib/validation.ts
@@ -1,0 +1,11 @@
+export function validateAddress(addr: string, label: string) {
+  if (!/^0x[0-9a-fA-F]{40}$/.test(addr)) {
+    throw new Error(`${label} address invalid`);
+  }
+}
+
+export function validatePositiveInt(value: string, label: string) {
+  if (!/^[0-9]+$/.test(value) || BigInt(value) <= 0n) {
+    throw new Error(`${label} must be > 0`);
+  }
+}


### PR DESCRIPTION
## Summary
- add reusable validation helpers
- enforce address and numeric checks when creating and updating plans
- test merchant and billing validation on create plan page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6867a685ffbc8333ba866f68ba997b52