### PR TITLE
Add upgrade integration test

### DIFF
--- a/docs/usage-examples.md
+++ b/docs/usage-examples.md
@@ -153,3 +153,15 @@ Environment=GRAPH_NODE_MAX_FAILS=5
 Environment=GRAPH_NODE_RESTART_DELAY=10000
 ExecStart=/usr/bin/npm run subgraph-server --prefix /opt/supscriptchain
 ```
+
+## Running Subgraph Integration Tests
+
+The integration tests spin up a local Hardhat node and a Graph Node Docker
+container. Ensure Docker is installed and running, then execute:
+
+```bash
+npx hardhat test subgraph/tests/integration.test.ts
+```
+
+This compiles the contracts, deploys both `SubscriptionUpgradeable` versions
+through a proxy and verifies indexed events by querying the running Graph Node.


### PR DESCRIPTION
## Summary
- expand `integration.test.ts` to deploy through a proxy, upgrade to V2 and run actions
- query the Graph node for totals and payments
- document how to run the integration test locally

## Testing
- `npm run lint` *(fails: ESLint couldn't find plugin)*
- `npm test` *(fails: 64 failing)*

------
https://chatgpt.com/codex/tasks/task_e_6867a684fd2c8333b018a07eae439f5f