### PR TITLE
Improve RPC error handling and message visuals

### DIFF
--- a/frontend/__tests__/MessageBar.test.tsx
+++ b/frontend/__tests__/MessageBar.test.tsx
@@ -8,7 +8,7 @@ test('shows and hides message', async () => {
     const { setMessage } = useStore();
     return (
       <div>
-        <button onClick={() => setMessage('hello')}>set</button>
+        <button onClick={() => setMessage({ text: 'hello', type: 'success' })}>set</button>
         <MessageBar />
       </div>
     );
@@ -19,7 +19,9 @@ test('shows and hides message', async () => {
     </StoreProvider>
   );
   await userEvent.click(screen.getByText('set'));
-  expect(screen.getByText('hello')).toBeInTheDocument();
-  await userEvent.click(screen.getByText('hello'));
+  const bar = screen.getByText('hello');
+  expect(bar).toBeInTheDocument();
+  expect(bar.className).toContain('success');
+  await userEvent.click(bar);
   expect(screen.queryByText('hello')).toBeNull();
 });

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -48,10 +48,18 @@ body {
 }
 
 .message-bar {
-  background: #e0ffe0;
   padding: 8px;
   margin-bottom: 8px;
   border-radius: 4px;
+}
+.message-bar.success {
+  background: #e0ffe0;
+}
+.message-bar.error {
+  background: #ffe0e0;
+}
+.message-bar.warning {
+  background: #fff5cc;
 }
 
 .error {

--- a/frontend/app/manage/page.tsx
+++ b/frontend/app/manage/page.tsx
@@ -24,11 +24,11 @@ export default function Manage() {
       const contract = await getContract();
       const tx = await contract.subscribe(BigInt(planId));
       await tx.wait();
-      setMessage(`Subscribed! Tx: ${tx.hash}`);
+      setMessage({ text: `Subscribed! Tx: ${tx.hash}`, type: 'success' });
     } catch (err) {
       console.error(err);
       const message = err instanceof Error ? err.message : String(err);
-      setMessage(message);
+      setMessage({ text: message, type: 'error' });
     } finally {
       setLoading(false);
     }
@@ -41,18 +41,18 @@ export default function Manage() {
       const contract = await getContract();
       const tx = await contract.cancelSubscription(BigInt(planId));
       await tx.wait();
-      setMessage(`Cancelled! Tx: ${tx.hash}`);
+      setMessage({ text: `Cancelled! Tx: ${tx.hash}`, type: 'success' });
     } catch (err) {
       console.error(err);
       const message = err instanceof Error ? err.message : String(err);
-      setMessage(message);
+      setMessage({ text: message, type: 'error' });
     } finally {
       setLoading(false);
     }
   }
 
   async function requestPermit() {
-    if (!account) return setMessage('Connect Wallet first');
+    if (!account) return setMessage({ text: 'Connect Wallet first', type: 'warning' });
     setLoading(true);
     setError(null);
     try {
@@ -120,11 +120,11 @@ export default function Manage() {
         s as `0x${string}`
       );
       await tx.wait();
-      setMessage(`Subscribed with permit! Tx: ${tx.hash}`);
+      setMessage({ text: `Subscribed with permit! Tx: ${tx.hash}`, type: 'success' });
     } catch (err) {
       console.error(err);
       const message = err instanceof Error ? err.message : String(err);
-      setMessage(message);
+      setMessage({ text: message, type: 'error' });
     } finally {
       setLoading(false);
     }

--- a/frontend/app/payment/page.tsx
+++ b/frontend/app/payment/page.tsx
@@ -21,11 +21,11 @@ export default function Payment() {
       const contract = await getContract();
       const tx = await contract.processPayment(user, BigInt(planId));
       await tx.wait();
-      setMessage(`Payment processed! Tx: ${tx.hash}`);
+      setMessage({ text: `Payment processed! Tx: ${tx.hash}`, type: 'success' });
     } catch (err) {
       console.error(err);
       const message = err instanceof Error ? err.message : String(err);
-      setMessage(message);
+      setMessage({ text: message, type: 'error' });
     } finally {
       setLoading(false);
     }

--- a/frontend/app/plans/create/page.tsx
+++ b/frontend/app/plans/create/page.tsx
@@ -41,7 +41,7 @@ export default function CreatePlan() {
         feed || '0x0000000000000000000000000000000000000000'
       );
       await tx.wait();
-      setMessage(`Plan created: ${tx.hash}`);
+      setMessage({ text: `Plan created: ${tx.hash}`, type: 'success' });
     } catch (err) {
       console.error(err);
       setError(err instanceof Error ? err.message : String(err));

--- a/frontend/app/plans/manage/page.tsx
+++ b/frontend/app/plans/manage/page.tsx
@@ -30,7 +30,7 @@ export default function ManagePlans() {
         '0x0000000000000000000000000000000000000000'
       );
       await tx.wait();
-      setMessage('Plan updated');
+      setMessage({ text: 'Plan updated', type: 'success' });
       await reload();
     } catch (err) {
       console.error(err);

--- a/frontend/app/plans/update/page.tsx
+++ b/frontend/app/plans/update/page.tsx
@@ -39,7 +39,7 @@ export default function UpdatePlan() {
         feed || '0x0000000000000000000000000000000000000000'
       );
       await tx.wait();
-      setMessage(`Plan updated: ${tx.hash}`);
+      setMessage({ text: `Plan updated: ${tx.hash}`, type: 'success' });
     } catch (err) {
       console.error(err);
       setError(err instanceof Error ? err.message : String(err));

--- a/frontend/lib/MessageBar.tsx
+++ b/frontend/lib/MessageBar.tsx
@@ -4,9 +4,10 @@ import { useStore } from './store';
 export default function MessageBar() {
   const { message, setMessage } = useStore();
   if (!message) return null;
+  const className = `message-bar ${message.type ?? ''}`.trim();
   return (
-    <div className="message-bar" onClick={() => setMessage(null)}>
-      {message}
+    <div className={className} onClick={() => setMessage(null)}>
+      {message.text}
     </div>
   );
 }

--- a/frontend/lib/contract.ts
+++ b/frontend/lib/contract.ts
@@ -6,6 +6,18 @@ import { env } from "./env";
 
 function parseEthersError(err: unknown): string {
   const e = err as any;
+  const rpc = e?.error ?? e;
+  if (rpc && typeof rpc === "object" && "message" in rpc) {
+    let msg = (rpc as any).message as string;
+    if (typeof (rpc as any).code !== "undefined") {
+      msg += ` (code ${(rpc as any).code})`;
+    }
+    if ((rpc as any).data) {
+      const d = (rpc as any).data;
+      msg += `: ${typeof d === "string" ? d : JSON.stringify(d)}`;
+    }
+    return msg;
+  }
   return (
     e?.shortMessage ||
     e?.reason ||

--- a/frontend/lib/store.tsx
+++ b/frontend/lib/store.tsx
@@ -1,15 +1,20 @@
 'use client';
 import { createContext, useContext, useState } from 'react';
 
+export interface Message {
+  text: string;
+  type?: 'success' | 'warning' | 'error';
+}
+
 interface State {
-  message: string | null;
-  setMessage: (m: string | null) => void;
+  message: Message | null;
+  setMessage: (m: Message | null) => void;
 }
 
 const Ctx = createContext<State | undefined>(undefined);
 
 export function StoreProvider({ children }: { children: React.ReactNode }) {
-  const [message, setMessage] = useState<string | null>(null);
+  const [message, setMessage] = useState<Message | null>(null);
   return <Ctx.Provider value={{ message, setMessage }}>{children}</Ctx.Provider>;
 }
 

--- a/frontend/lib/useWallet.ts
+++ b/frontend/lib/useWallet.ts
@@ -34,7 +34,7 @@ export default function useWallet() {
         await wc.enable();
         eth = wc as unknown as EthereumProvider;
       } catch {
-        setMessage("Wallet not found");
+        setMessage({ text: "Wallet not found", type: 'warning' });
         return;
       }
     }
@@ -43,7 +43,7 @@ export default function useWallet() {
       setAccount(accounts[0]);
     } catch (err) {
       const msg = err instanceof Error ? err.message : "Failed to connect";
-      setMessage(msg);
+      setMessage({ text: msg, type: 'error' });
     }
   }
 


### PR DESCRIPTION
## Summary
- show RPC `code` and `data` in `parseEthersError`
- support typed messages in Store context
- style MessageBar according to message type
- propagate message objects across pages
- update tests for new MessageBar format

## Testing
- `npm test` in `frontend`
- `npm test` *(fails: hardhat not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867b9cdd9f88333ab8e96a829a50e78