### PR TITLE
Add coverage generation to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,3 +25,10 @@ jobs:
         run: npm run test-subgraph
       - name: Run e2e tests
         run: npm run test:e2e
+      - name: Generate coverage report
+        run: npm run coverage
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v3
+        with:
+          name: coverage-report
+          path: coverage


### PR DESCRIPTION
## Summary
- run `npm run coverage` in CI
- upload coverage output as workflow artifact

## Testing
- `npm ci` *(fails: ERESOLVE could not resolve)*
- `npm test` *(fails: hardhat not found)*

------
https://chatgpt.com/codex/tasks/task_e_68681a515c0483338760cfb3e3630a9e