### PR TITLE
Fix CI badge link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Supscriptchain
 
-[![CI](https://github.com/OWNER/Supscriptchain/actions/workflows/ci.yml/badge.svg)](https://github.com/OWNER/Supscriptchain/actions/workflows/ci.yml)
+[![CI](https://github.com/<Organisation oder Nutzername>/Supscriptchain/actions/workflows/ci.yml/badge.svg)](https://github.com/<Organisation oder Nutzername>/Supscriptchain/actions/workflows/ci.yml)
 
 This project contains a simple subscription smart contract written in Solidity along with TypeScript tests using Hardhat. It allows merchants to create subscription plans that can be paid in ERC20 tokens or in USD via a Chainlink price feed.
 


### PR DESCRIPTION
## Summary
- update CI badge placeholder to `<Organisation oder Nutzername>`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68681a52297083339c10affc6124dd5d