### PR TITLE
Update build-subgraph script

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,8 +301,8 @@ building. These variables are also used by `npm run prepare-subgraph`:
 NETWORK=sepolia CONTRACT_ADDRESS=0xYourContract npm run build-subgraph
 ```
 
-This command runs `npm run prepare-subgraph` internally and produces
-`subgraph/subgraph.local.yaml`.
+This command runs `npm run codegen` and `npm run prepare-subgraph` internally and
+produces `subgraph/subgraph.local.yaml`.
 
 See [docs/usage-examples.md#running-the-subgraph-locally](docs/usage-examples.md#running-the-subgraph-locally)
 for a step-by-step guide on `npm run prepare-subgraph` and `npm run build-subgraph`.

--- a/docs/usage-examples.md
+++ b/docs/usage-examples.md
@@ -44,7 +44,8 @@ OpenZeppelin upgrades file in `.openzeppelin/`, the script automatically reads
 the network and address from those files. If nothing can be detected, provide
 the values via environment variables or CLI arguments.
 
-1. Generate the types with `npm run codegen`.
+1. Generate the types with `npm run codegen` (automatically done by
+   `npm run build-subgraph`).
 2. Run `npm run prepare-subgraph` to create `subgraph/subgraph.local.yaml`.
 
 ```bash
@@ -58,7 +59,8 @@ npm run prepare-subgraph
 
 ### 4. Build the Subgraph
 
-The build script first runs `prepare-subgraph` and then compiles the subgraph:
+The build script runs `npm run codegen` and `npm run prepare-subgraph` before
+compiling the subgraph:
 
 ```bash
 npm run build-subgraph -- --network $NETWORK --address $CONTRACT_ADDRESS

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "typechain": "typechain --target ethers-v6 --out-dir typechain ./artifacts/**/*.json",
     "codegen": "graph codegen subgraph/subgraph.yaml",
     "prepare-subgraph": "npx --yes ts-node scripts/prepare-subgraph.ts",
-    "build-subgraph": "npm run prepare-subgraph && graph build subgraph/subgraph.local.yaml",
+    "build-subgraph": "npm run prepare-subgraph && npm run codegen && graph build subgraph/subgraph.local.yaml",
     "prepare": "husky install",
     "subgraph-server": "ts-node scripts/subgraph-server.ts",
     "coverage": "hardhat coverage",


### PR DESCRIPTION
## Summary
- ensure `npm run build-subgraph` also runs codegen
- document that codegen runs automatically when building the subgraph

## Testing
- `npm test` *(fails: hardhat not found)*

------
https://chatgpt.com/codex/tasks/task_e_68683cc522d48333a57f8f07db4db173