### PR TITLE
Add .dockerignore and streamline payments Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,29 @@
+# Dependency directories
+node_modules
+frontend/node_modules
+
+# Version control
+.git
+
+# Build artifacts
+artifacts
+cache
+dist
+build
+
+# Logs and coverage
+*.log
+logs/
+coverage
+
+# IDE/OS files
+.vscode
+.idea
+.DS_Store
+
+# Environment files
+.env
+.env.*
+
+# Next.js build output
+frontend/.next

--- a/Dockerfile.payments
+++ b/Dockerfile.payments
@@ -2,5 +2,9 @@ FROM node:20-alpine
 WORKDIR /app
 COPY package.json package-lock.json ./
 RUN npm ci --legacy-peer-deps
-COPY . .
+
+# Copy only the files required to run the payment processor
+COPY hardhat.config.ts tsconfig.json ./
+COPY scripts ./scripts
+COPY contracts ./contracts
 CMD ["npx", "ts-node", "scripts/process-due-payments.ts"]


### PR DESCRIPTION
## Summary
- prevent unnecessary files from being sent to Docker by adding `.dockerignore`
- copy only needed directories in `Dockerfile.payments`

## Testing
- `npm test` *(fails: `hardhat` not found)*
- `npm ci` *(fails due to ERESOLVE dependency conflict)*

------
https://chatgpt.com/codex/tasks/task_e_686911c9145c83338c17aa529dcbd800