### PR TITLE
Add env variable tests

### DIFF
--- a/frontend/__tests__/env.test.ts
+++ b/frontend/__tests__/env.test.ts
@@ -1,0 +1,33 @@
+import { jest } from '@jest/globals';
+
+const originalEnv = { ...process.env };
+
+beforeEach(() => {
+  jest.resetModules();
+  process.env = { ...originalEnv };
+});
+
+test('exports validated env variables', async () => {
+  process.env.NEXT_PUBLIC_CONTRACT_ADDRESS = '0x1111111111111111111111111111111111111111';
+  process.env.NEXT_PUBLIC_CHAIN_ID = '42';
+  process.env.NEXT_PUBLIC_RPC_URL = 'https://example.com';
+  process.env.NEXT_PUBLIC_SUBGRAPH_URL = 'https://example.com/subgraph';
+
+  const mod = await import('../lib/env');
+  expect(mod.env).toEqual({
+    NEXT_PUBLIC_CONTRACT_ADDRESS: '0x1111111111111111111111111111111111111111',
+    NEXT_PUBLIC_CHAIN_ID: 42,
+    NEXT_PUBLIC_RPC_URL: 'https://example.com',
+    NEXT_PUBLIC_SUBGRAPH_URL: 'https://example.com/subgraph',
+  });
+});
+
+test('throws when variable missing', async () => {
+  delete process.env.NEXT_PUBLIC_RPC_URL;
+  await expect(import('../lib/env')).rejects.toThrow();
+});
+
+test('throws when variable invalid', async () => {
+  process.env.NEXT_PUBLIC_RPC_URL = 'not-a-url';
+  await expect(import('../lib/env')).rejects.toThrow();
+});

--- a/frontend/jest.config.js
+++ b/frontend/jest.config.js
@@ -1,6 +1,7 @@
 module.exports = {
   preset: 'ts-jest/presets/js-with-ts-esm',
   testEnvironment: 'jsdom',
+  testMatch: ['<rootDir>/__tests__/**/*.test.ts?(x)'],
   setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
   extensionsToTreatAsEsm: ['.ts', '.tsx'],
   moduleNameMapper: {


### PR DESCRIPTION
## Summary
- add tests for frontend env validation
- ensure jest matches test files explicitly

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686911c7df6c833390f98f5c126eedab