### PR TITLE
Use fixed graph-node version

### DIFF
--- a/subgraph/tests/integration.test.ts
+++ b/subgraph/tests/integration.test.ts
@@ -60,7 +60,7 @@ describe('Subgraph integration', function () {
         'ethereum=hardhat:http://host.docker.internal:8545',
         '-e',
         'ipfs=host.docker.internal:5001',
-        'graphprotocol/graph-node:latest',
+        'graphprotocol/graph-node:v0.33.0',
       ],
       { stdio: 'inherit' },
     );


### PR DESCRIPTION
## Summary
- fix the docker image tag for the integration test

## Testing
- `npx --yes hardhat test subgraph/tests/integration.test.ts` *(fails: Hardhat not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686911c53844833392f7052144fee5af