### PR TITLE
Add Prometheus metrics

### DIFF
--- a/docs/production-guide.md
+++ b/docs/production-guide.md
@@ -59,3 +59,35 @@ For the subgraph, monitor the Graph Node via its `/health` endpoint. The helper 
 Consider setting up additional service-level monitoring for your contract interactions and Docker containers.
 
 - Expose metrics to Prometheus and build Grafana dashboards to visualize contract and service performance.
+
+### Example Prometheus Setup
+
+The helper script exposes metrics on `localhost:9091/metrics` by default.
+Run it with:
+
+```bash
+METRICS_PORT=9091 npm run subgraph-server
+```
+
+Add a scrape configuration in your Prometheus `prometheus.yml`:
+
+```yaml
+scrape_configs:
+  - job_name: 'subgraph'
+    static_configs:
+      - targets: ['localhost:9091']
+```
+
+Example alert rule for Prometheus:
+
+```yaml
+alert: GraphNodeDown
+expr: graph_node_health_status == 0
+for: 5m
+labels:
+  severity: critical
+annotations:
+  summary: Graph node is not responding
+```
+
+Grafana can visualize these metrics using the Prometheus data source. Configure alert rules for high `graph_node_health_failures_total` or when `graph_node_health_status` remains `0` for an extended period. Alerts can send notifications via email, Slack or any supported service.

--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
   },
   "dependencies": {
     "@chainlink/contracts": "^1.4.0",
-    "@openzeppelin/contracts": "^4.9.3"
+    "@openzeppelin/contracts": "^4.9.3",
+    "prom-client": "^14.1.0"
   },
   "lint-staged": {
     "*": "prettier --check"

--- a/scripts/subgraph-server.ts
+++ b/scripts/subgraph-server.ts
@@ -1,6 +1,12 @@
 import { spawn, ChildProcessWithoutNullStreams } from 'child_process';
 import fs from 'fs';
 import http from 'http';
+import {
+  Counter,
+  Gauge,
+  Registry,
+  collectDefaultMetrics,
+} from 'prom-client';
 
 const cmd = process.env.GRAPH_NODE_CMD || 'graph-node';
 const args = process.env.GRAPH_NODE_ARGS
@@ -18,6 +24,36 @@ const restartDelay = parseInt(
 );
 const maxFails = parseInt(process.env.GRAPH_NODE_MAX_FAILS || '3', 10);
 const logPath = process.env.GRAPH_NODE_LOG || 'graph-node.log';
+const metricsPort = parseInt(process.env.METRICS_PORT || '9091', 10);
+const register = new Registry();
+collectDefaultMetrics({ register });
+const restartCounter = new Counter({
+  name: 'graph_node_restarts_total',
+  help: 'Total number of graph-node restarts',
+  registers: [register],
+});
+const healthFailures = new Counter({
+  name: 'graph_node_health_failures_total',
+  help: 'Total number of failed health checks',
+  registers: [register],
+});
+const healthStatus = new Gauge({
+  name: 'graph_node_health_status',
+  help: '1 if last health check succeeded, 0 otherwise',
+  registers: [register],
+});
+const metricsServer = http.createServer(async (req, res) => {
+  if (req.url === '/metrics') {
+    res.setHeader('Content-Type', register.contentType);
+    res.end(await register.metrics());
+  } else {
+    res.statusCode = 404;
+    res.end('Not Found');
+  }
+});
+metricsServer.listen(metricsPort, () => {
+  log(`Metrics server listening on port ${metricsPort}`);
+});
 let child: ChildProcessWithoutNullStreams;
 let fails = 0;
 
@@ -45,6 +81,7 @@ function start() {
     const msg = `graph-node exited with code ${code} signal ${signal}, restarting in ${restartDelay}ms`;
     console.error(msg);
     log(msg);
+    restartCounter.inc();
     setTimeout(start, restartDelay);
   });
 }
@@ -54,6 +91,7 @@ function restart() {
     child.kill();
   } catch {}
   log('Restarting graph-node');
+  restartCounter.inc();
   setTimeout(start, restartDelay);
 }
 
@@ -62,6 +100,8 @@ function check() {
     .get(healthUrl, (res) => {
       if (res.statusCode !== 200) {
         console.error(`Healthcheck failed with status ${res.statusCode}`);
+        healthFailures.inc();
+        healthStatus.set(0);
         if (++fails >= maxFails) {
           const msg = 'Max health check failures reached, restarting...';
           console.error(msg);
@@ -71,10 +111,13 @@ function check() {
         }
       } else {
         fails = 0;
+        healthStatus.set(1);
       }
     })
     .on('error', (err) => {
       console.error('Healthcheck error:', err.message);
+      healthFailures.inc();
+      healthStatus.set(0);
       if (++fails >= maxFails) {
         const msg = 'Max health check errors reached, restarting...';
         console.error(msg);


### PR DESCRIPTION
## Summary
- expose Prometheus metrics in `subgraph-server.ts`
- document a Prometheus/Grafana setup in production guide
- add dependency on `prom-client`

## Testing
- `npm test` *(fails: hardhat not found)*
- `npm run lint` *(fails: eslint plugin missing)*

------
https://chatgpt.com/codex/tasks/task_e_686917cbfe108333b89159a649b402ad