### PR TITLE
Add additional frontend tests

### DIFF
--- a/frontend/__tests__/Analytics.test.tsx
+++ b/frontend/__tests__/Analytics.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen } from '@testing-library/react';
+import Analytics from '../app/analytics/page';
+import { StoreProvider } from '../lib/store';
+
+jest.mock('../lib/subgraph', () => ({
+  getActiveSubscriptions: jest.fn(),
+  getPayments: jest.fn(),
+  getPlans: jest.fn(),
+}));
+import * as subgraph from '../lib/subgraph';
+jest.mock('../lib/useWallet', () => () => ({ account: '0xabc', connect: jest.fn() }));
+
+function Wrapper() {
+  return (
+    <StoreProvider>
+      <Analytics />
+    </StoreProvider>
+  );
+}
+
+describe('Analytics page', () => {
+  test('shows error when queries fail', async () => {
+    (subgraph.getActiveSubscriptions as jest.Mock).mockRejectedValue(new Error('fail'));
+    (subgraph.getPayments as jest.Mock).mockResolvedValue([]);
+    (subgraph.getPlans as jest.Mock).mockResolvedValue([]);
+    render(<Wrapper />);
+    expect(await screen.findByText('fail')).toBeInTheDocument();
+  });
+
+  test('renders data from subgraph', async () => {
+    (subgraph.getActiveSubscriptions as jest.Mock).mockResolvedValue([
+      { id: '1', user: 'u1', planId: '0', nextPaymentDate: '1' },
+    ]);
+    (subgraph.getPayments as jest.Mock).mockResolvedValue([
+      { id: '1', user: 'u1', planId: '0', amount: '5' },
+    ]);
+    (subgraph.getPlans as jest.Mock).mockResolvedValue([
+      { id: '0', totalPaid: '10' },
+    ]);
+    render(<Wrapper />);
+    expect(await screen.findByText(/next payment/)).toBeInTheDocument();
+    expect(screen.getByText(/total paid/)).toBeInTheDocument();
+    expect(screen.getByText(/amount/)).toBeInTheDocument();
+  });
+});

--- a/frontend/__tests__/HomePage.test.tsx
+++ b/frontend/__tests__/HomePage.test.tsx
@@ -1,0 +1,10 @@
+import { render, screen } from '@testing-library/react';
+import Home from '../app/page';
+
+describe('Home page', () => {
+  test('contains navigation links', () => {
+    render(<Home />);
+    expect(screen.getByText('Plan Overview')).toBeInTheDocument();
+    expect(screen.getByText('Analytics')).toBeInTheDocument();
+  });
+});

--- a/frontend/__tests__/ManagePlans.test.tsx
+++ b/frontend/__tests__/ManagePlans.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import ManagePlans from '../app/plans/manage/page';
+import { usePlans } from '../lib/plansStore';
+import { StoreProvider } from '../lib/store';
+import { updatePlan } from '../lib/contract';
+
+jest.mock('../lib/plansStore');
+jest.mock('../lib/contract', () => ({ updatePlan: jest.fn() }));
+jest.mock('../lib/useWallet', () => () => ({ account: '0xabc', connect: jest.fn() }));
+
+const mockUsePlans = usePlans as jest.Mock;
+const mockUpdate = updatePlan as jest.Mock;
+
+function Wrapper() {
+  return (
+    <StoreProvider>
+      <ManagePlans />
+    </StoreProvider>
+  );
+}
+
+describe('ManagePlans page', () => {
+  test('validates billing input', async () => {
+    mockUsePlans.mockReturnValue({ plans: [{}], reload: jest.fn() });
+    render(<Wrapper />);
+    await userEvent.selectOptions(screen.getByRole('combobox'), ['0']);
+    await userEvent.click(screen.getByText('Update'));
+    expect(await screen.findByText('billing > 0')).toBeInTheDocument();
+    expect(mockUpdate).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/__tests__/PlansPage.test.tsx
+++ b/frontend/__tests__/PlansPage.test.tsx
@@ -1,0 +1,28 @@
+import { render, screen } from '@testing-library/react';
+import Plans from '../app/plans/page';
+import { StoreProvider } from '../lib/store';
+
+const mockUsePlans = jest.fn();
+jest.mock('../lib/plansStore', () => ({ usePlans: () => mockUsePlans() }));
+jest.mock('../lib/useWallet', () => () => ({ account: '0xabc', connect: jest.fn() }));
+
+function Wrapper() {
+  return (
+    <StoreProvider>
+      <Plans />
+    </StoreProvider>
+  );
+}
+
+describe('Plans page', () => {
+  test('renders list of plans', () => {
+    mockUsePlans.mockReturnValue({
+      plans: [
+        { merchant: '0x', token: 'a', tokenDecimals: 18n, price: 1n, billingCycle: 1n, priceInUsd: false, usdPrice: 0n, priceFeedAddress: '0x' },
+      ],
+      reload: jest.fn(),
+    });
+    render(<Wrapper />);
+    expect(screen.getByText(/Plan 0/)).toBeInTheDocument();
+  });
+});

--- a/frontend/__tests__/UpdatePlanPage.test.tsx
+++ b/frontend/__tests__/UpdatePlanPage.test.tsx
@@ -1,0 +1,29 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import UpdatePlan from '../app/plans/update/page';
+import { StoreProvider } from '../lib/store';
+import { updatePlan } from '../lib/contract';
+
+jest.mock('../lib/contract', () => ({ updatePlan: jest.fn() }));
+jest.mock('../lib/useWallet', () => () => ({ account: '0xabc', connect: jest.fn() }));
+
+const mockUpdate = updatePlan as jest.Mock;
+
+function Wrapper() {
+  return (
+    <StoreProvider>
+      <UpdatePlan />
+    </StoreProvider>
+  );
+}
+
+describe('UpdatePlan page', () => {
+  test('validates plan id', async () => {
+    render(<Wrapper />);
+    await userEvent.type(screen.getByLabelText('Billing (seconds)'), '1');
+    await userEvent.type(screen.getByLabelText('Token Price'), '1');
+    await userEvent.click(screen.getByText('Update'));
+    expect(await screen.findByText('plan id required')).toBeInTheDocument();
+    expect(mockUpdate).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/__tests__/plansStore.test.tsx
+++ b/frontend/__tests__/plansStore.test.tsx
@@ -1,0 +1,59 @@
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { PlansProvider, usePlans, Plan } from '../lib/plansStore';
+import { getContract } from '../lib/contract';
+
+jest.mock('../lib/contract', () => ({ getContract: jest.fn() }));
+
+const mockedGetContract = getContract as jest.Mock;
+
+function makePlan(token: string): Plan {
+  return {
+    merchant: '0x',
+    token,
+    tokenDecimals: 18n,
+    price: 1n,
+    billingCycle: 1n,
+    priceInUsd: false,
+    usdPrice: 0n,
+    priceFeedAddress: '0x',
+  };
+}
+
+describe('plansStore', () => {
+  test('loads plans on mount and reloads', async () => {
+    const contract = {
+      nextPlanId: jest.fn().mockResolvedValue(2n),
+      plans: jest
+        .fn()
+        .mockResolvedValueOnce(makePlan('t1'))
+        .mockResolvedValueOnce(makePlan('t2')),
+    };
+    mockedGetContract.mockResolvedValue(contract);
+    const { result } = renderHook(() => usePlans(), {
+      wrapper: PlansProvider,
+    });
+    await waitFor(() => expect(result.current.plans).toHaveLength(2));
+    expect(result.current.plans).toHaveLength(2);
+    expect(contract.nextPlanId).toHaveBeenCalled();
+
+    contract.plans
+      .mockResolvedValueOnce(makePlan('t3'))
+      .mockResolvedValueOnce(makePlan('t4'));
+    await act(async () => {
+      await result.current.reload();
+    });
+    expect(result.current.plans[0].token).toBe('t3');
+  });
+
+  test('handles errors gracefully', async () => {
+    const contract = {
+      nextPlanId: jest.fn().mockRejectedValue(new Error('fail')),
+    };
+    mockedGetContract.mockResolvedValue(contract);
+    const { result } = renderHook(() => usePlans(), {
+      wrapper: PlansProvider,
+    });
+    await waitFor(() => expect(result.current.plans).toHaveLength(0));
+    expect(result.current.plans).toHaveLength(0);
+  });
+});

--- a/frontend/__tests__/subgraph.test.ts
+++ b/frontend/__tests__/subgraph.test.ts
@@ -1,0 +1,41 @@
+import { ApolloClient } from '@apollo/client';
+
+const queryMock = jest.fn();
+
+jest.mock('@apollo/client', () => {
+  const original = jest.requireActual('@apollo/client');
+  return {
+    ...original,
+    ApolloClient: jest.fn().mockImplementation(() => ({ query: queryMock })),
+    InMemoryCache: jest.fn(),
+    gql: original.gql,
+  };
+});
+
+describe('subgraph', () => {
+  beforeEach(() => {
+    queryMock.mockReset();
+  });
+
+  test('getActiveSubscriptions returns data', async () => {
+    const { getActiveSubscriptions, ACTIVE_SUBSCRIPTIONS_QUERY } = await import('../lib/subgraph');
+    queryMock.mockResolvedValue({ data: { subscriptions: [{ id: '1' }] } });
+    const res = await getActiveSubscriptions();
+    expect(res).toEqual([{ id: '1' }]);
+    expect(queryMock).toHaveBeenCalledWith({ query: ACTIVE_SUBSCRIPTIONS_QUERY });
+  });
+
+  test('getActiveSubscriptions propagates errors', async () => {
+    const { getActiveSubscriptions } = await import('../lib/subgraph');
+    queryMock.mockRejectedValue(new Error('fail'));
+    await expect(getActiveSubscriptions()).rejects.toThrow('fail');
+  });
+
+  test('getPlans works', async () => {
+    const { getPlans, PLANS_QUERY } = await import('../lib/subgraph');
+    queryMock.mockResolvedValue({ data: { plans: [{ id: '1' }] } });
+    const plans = await getPlans();
+    expect(plans[0].id).toBe('1');
+    expect(queryMock).toHaveBeenCalledWith({ query: PLANS_QUERY });
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for subgraph helpers and plans store
- cover analytics, home, plans, manage plans and update plan pages
- mock GraphQL calls to test error handling

## Testing
- `npm test --prefix frontend`

------
https://chatgpt.com/codex/tasks/task_e_68692775212c8333912c6134bc618eba