### PR TITLE
Add manual approval and staged release

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -6,11 +6,22 @@ on:
     paths:
       - 'frontend/**'
   workflow_dispatch:
+    inputs:
+      skip_approval:
+        description: 'Skip manual approval'
+        required: false
+        default: 'false'
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
+      - name: Await approval
+        if: ${{ github.event.inputs.skip_approval != 'true' }}
+        uses: trstringer/manual-approval@v1
+        with:
+          secret: ${{ secrets.GITHUB_TOKEN }}
+          approvers: ${{ github.repository_owner }}
       - uses: actions/checkout@v3
       - name: Setup Node
         uses: actions/setup-node@v3

--- a/.github/workflows/deploy-mainnet.yml
+++ b/.github/workflows/deploy-mainnet.yml
@@ -2,6 +2,11 @@ name: Deploy Mainnet
 
 on:
   workflow_dispatch:
+    inputs:
+      skip_approval:
+        description: 'Skip manual approval'
+        required: false
+        default: 'false'
   push:
     tags:
       - 'v*.*.*'
@@ -10,6 +15,12 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
+      - name: Await approval
+        if: ${{ github.event.inputs.skip_approval != 'true' }}
+        uses: trstringer/manual-approval@v1
+        with:
+          secret: ${{ secrets.GITHUB_TOKEN }}
+          approvers: ${{ github.repository_owner }}
       - uses: actions/checkout@v3
       - name: Setup Node
         uses: actions/setup-node@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,15 +1,37 @@
 name: Release
 
 on:
-  push:
-    tags:
-      - 'v*.*.*'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release version without the v-prefix'
+        required: true
+      require_approval:
+        description: 'Require manual approval before deployment'
+        required: false
+        default: 'true'
 
 jobs:
-  build:
+  tag:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Create tag
+        run: |
+          git config user.name "${{ github.actor }}"
+          git config user.email "${{ github.actor }}@users.noreply.github.com"
+          git tag -a "v${{ inputs.version }}" -m "Release v${{ inputs.version }}"
+          git push origin "v${{ inputs.version }}"
+
+  build:
+    runs-on: ubuntu-latest
+    needs: tag
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
@@ -32,10 +54,81 @@ jobs:
           tar czf contracts.tar.gz artifacts
           tar czf subgraph.tar.gz subgraph/build
           tar czf frontend.tar.gz -C frontend .next
+      - name: Generate changelog
+        id: changelog
+        run: |
+          LAST_TAG=$(git describe --tags --abbrev=0 HEAD^)
+          git log ${LAST_TAG}..HEAD --pretty=format:'- %s (%an)' > CHANGELOG.md
       - name: Create release
         uses: softprops/action-gh-release@v1
         with:
+          tag_name: v${{ inputs.version }}
+          body_path: CHANGELOG.md
           files: |
             contracts.tar.gz
             subgraph.tar.gz
             frontend.tar.gz
+
+  deploy-mainnet:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Await approval for Mainnet deployment
+        if: ${{ inputs.require_approval != 'false' }}
+        uses: trstringer/manual-approval@v1
+        with:
+          secret: ${{ secrets.GITHUB_TOKEN }}
+          approvers: ${{ github.repository_owner }}
+      - uses: actions/checkout@v3
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+          cache: 'npm'
+          cache-dependency-path: package-lock.json
+      - name: Install dependencies
+        run: npm ci
+      - name: Deploy to Mainnet
+        env:
+          MAINNET_RPC_URL: ${{ secrets.MAINNET_RPC_URL }}
+          MAINNET_PRIVATE_KEY: ${{ secrets.MAINNET_PRIVATE_KEY }}
+          MERCHANT_ADDRESS: ${{ secrets.MERCHANT_ADDRESS }}
+          TOKEN_ADDRESS: ${{ secrets.TOKEN_ADDRESS }}
+          PRICE_FEED: ${{ secrets.PRICE_FEED }}
+          BILLING_CYCLE: ${{ secrets.BILLING_CYCLE }}
+          PRICE_IN_USD: ${{ secrets.PRICE_IN_USD }}
+          FIXED_PRICE: ${{ secrets.FIXED_PRICE }}
+          USD_PRICE: ${{ secrets.USD_PRICE }}
+        run: npx hardhat run scripts/deploy.ts --network mainnet
+
+  deploy-frontend:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Await approval for Vercel deployment
+        if: ${{ inputs.require_approval != 'false' }}
+        uses: trstringer/manual-approval@v1
+        with:
+          secret: ${{ secrets.GITHUB_TOKEN }}
+          approvers: ${{ github.repository_owner }}
+      - uses: actions/checkout@v3
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+      - name: Install dependencies
+        run: npm ci
+        working-directory: frontend
+      - name: Build frontend
+        run: npm run build
+        working-directory: frontend
+      - name: Deploy to Vercel
+        uses: amondnet/vercel-action@v25
+        with:
+          vercel-token: ${{ secrets.VERCEL_TOKEN }}
+          vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
+          vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
+          working-directory: ./frontend
+          prod: true


### PR DESCRIPTION
## Summary
- expand release workflow into tagging, changelog creation and deployment jobs
- request manual approval before deploying mainnet and Vercel
- allow skipping approval in dedicated deploy workflows

## Testing
- `npm test` *(fails: hardhat not found)*
- `npm ci` *(fails: dependency resolution errors)*

------
https://chatgpt.com/codex/tasks/task_e_6869277327b48333bee9e6882cc0fe5c