### PR TITLE
Add docker compose setup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,40 @@
+version: '3.9'
+services:
+  hardhat:
+    image: node:20
+    working_dir: /app
+    volumes:
+      - ./:/app
+    command: npx hardhat node
+    ports:
+      - "8545:8545"
+
+  subgraph:
+    image: node:20
+    working_dir: /app
+    volumes:
+      - ./:/app
+    command: npm run subgraph-server
+    env_file:
+      - .env
+    depends_on:
+      - hardhat
+    ports:
+      - "8000:8000"
+      - "8020:8020"
+      - "9091:9091"
+
+  frontend:
+    image: node:20
+    working_dir: /app/frontend
+    volumes:
+      - ./frontend:/app/frontend
+      - ./package.json:/app/package.json:ro
+      - ./package-lock.json:/app/package-lock.json:ro
+    command: sh -c "npm run build && npm start"
+    env_file:
+      - .env
+    depends_on:
+      - hardhat
+    ports:
+      - "3000:3000"

--- a/docs/usage-examples.md
+++ b/docs/usage-examples.md
@@ -170,3 +170,17 @@ npx hardhat test subgraph/tests/integration.test.ts
 
 This compiles the contracts, deploys both `SubscriptionUpgradeable` versions
 through a proxy and verifies indexed events by querying the running Graph Node.
+
+## Lokaler Komplettbetrieb
+
+Eine `docker-compose.yml` im Projektroot startet Hardhat, den Subgraph-Server und das Frontend.
+Legen Sie eine `.env`-Datei an, um Variablen für `subgraph` und `frontend` bereitzustellen.
+
+Starten der gesamten Umgebung:
+
+```bash
+docker compose up --build
+```
+
+Hardhat läuft anschließend auf Port 8545, der Graph Node auf 8000 und das
+Frontend unter <http://localhost:3000>.


### PR DESCRIPTION
## Summary
- add a docker-compose file to spin up the full stack
- document how to run everything via compose

## Testing
- `npm run lint` *(fails: plugin not found)*
- `npm install` *(fails: dependency resolution conflict)*

------
https://chatgpt.com/codex/tasks/task_e_686943e851b083339321abe7f2d4b8fc