### PR TITLE
Add monitoring docs

### DIFF
--- a/docs/examples/prometheus.yml
+++ b/docs/examples/prometheus.yml
@@ -1,0 +1,10 @@
+# Example Prometheus configuration
+# Scrapes metrics from the subgraph server on port 9091.
+
+global:
+  scrape_interval: 15s
+
+scrape_configs:
+  - job_name: 'subgraph-server'
+    static_configs:
+      - targets: ['localhost:9091']


### PR DESCRIPTION
## Summary
- document new monitoring section in the production guide
- provide example prometheus.yml

## Testing
- `npm test` *(fails: hardhat not found)*

------
https://chatgpt.com/codex/tasks/task_e_686943e9da888333ad87bbaae555be8a