### PR TITLE
Document Slither warning for _processPayment

### DIFF
--- a/contracts/BaseSubscription.sol
+++ b/contracts/BaseSubscription.sol
@@ -271,6 +271,8 @@ abstract contract BaseSubscription {
 
         // Interactions
         require(token.allowance(_user, address(this)) >= amountToPay, "Insufficient allowance");
+        // Slither warns about arbitrary-from in transferFrom. The allowance check
+        // above and the merchant-only access control ensure this call is safe.
         token.safeTransferFrom(_user, plan.merchant, amountToPay);
 
         emit PaymentProcessed(_user, _planId, amountToPay, userSub.nextPaymentDate);

--- a/docs/security-audit.md
+++ b/docs/security-audit.md
@@ -16,3 +16,11 @@ npm run slither
 _No high severity issues were found._ The tool reported informational messages
 about naming conventions and optimizer settings. Review the full report for
 details and address any warnings relevant to your deployment.
+
+### Arbitrary-from in `_processPayment`
+
+Slither flags the call to `safeTransferFrom` inside
+`BaseSubscription._processPayment` because tokens are transferred from a user
+address rather than `msg.sender`. The function requires the merchant to be the
+caller and checks the user's allowance before performing the transfer. This
+pattern is intentional for subscription payments and is considered safe.


### PR DESCRIPTION
## Summary
- clarify why safeTransferFrom uses `_user` in `_processPayment`
- document the Slither warning as acceptable

## Testing
- `npm test` *(fails: price overflow)*

------
https://chatgpt.com/codex/tasks/task_e_686943e974208333b30a1c5656d0041f