### PR TITLE
Add start-subgraph script

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,6 +311,15 @@ npm run deploy-subgraph
 That section also lists the required environment variables and explains how to
 configure `NEXT_PUBLIC_SUBGRAPH_URL` for the frontend.
 
+To run a Graph Node locally with automatic restarts, use:
+
+```bash
+./scripts/start-subgraph.sh [path/to/.env]
+```
+
+The script loads the optional `.env` file and then invokes
+`ts-node scripts/subgraph-server.ts`.
+
 ## Frontend
 
 The repository also contains a simple Next.js application under

--- a/scripts/start-subgraph.sh
+++ b/scripts/start-subgraph.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+# Start subgraph-server.ts with optional .env file
+# Usage: ./scripts/start-subgraph.sh [path/to/.env]
+
+set -euo pipefail
+
+ENV_FILE="${1:-.env}"
+
+if [ -f "$ENV_FILE" ]; then
+  set -o allexport
+  source "$ENV_FILE"
+  set +o allexport
+else
+  if [ -n "${1:-}" ]; then
+    echo "Environment file '$ENV_FILE' not found" >&2
+    exit 1
+  fi
+fi
+
+exec npx ts-node scripts/subgraph-server.ts


### PR DESCRIPTION
## Summary
- add new helper script `start-subgraph.sh`
- document usage of the new script in the Subgraph section of the README

## Testing
- `npm test` *(fails: hardhat not found)*
- `npm install` *(fails to resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6869591d57bc8333bab8fd7d9daa9aba