### PR TITLE
Add coverage step to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    env:
+      COVERAGE_THRESHOLD: '70'
     steps:
       - uses: actions/checkout@v3
       - name: Setup Node
@@ -32,3 +34,12 @@ jobs:
         run: npm run solhint
       - name: Run Slither
         run: npm run slither
+      - name: Run coverage
+        run: npm run coverage
+      - name: Check coverage threshold
+        run: npm run coverage-check
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: coverage

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "prepare": "husky install",
     "subgraph-server": "ts-node scripts/subgraph-server.ts",
     "coverage": "hardhat coverage",
+    "coverage-check": "node scripts/check-coverage.js",
     "slither": "slither .",
     "test-subgraph": "graph test",
     "test:e2e": "playwright test"

--- a/scripts/check-coverage.js
+++ b/scripts/check-coverage.js
@@ -1,0 +1,28 @@
+const fs = require('fs');
+const threshold = parseFloat(process.env.COVERAGE_THRESHOLD || '0');
+if (!threshold) {
+  console.log('No coverage threshold set; skipping check.');
+  process.exit(0);
+}
+
+const file = 'coverage/coverage-final.json';
+if (!fs.existsSync(file)) {
+  console.error(`Coverage file ${file} not found.`);
+  process.exit(1);
+}
+
+const data = JSON.parse(fs.readFileSync(file, 'utf8'));
+let total = 0;
+let covered = 0;
+for (const cov of Object.values(data)) {
+  for (const count of Object.values(cov.l)) {
+    total++;
+    if (count > 0) covered++;
+  }
+}
+const percent = (covered / total) * 100;
+console.log(`Line coverage: ${percent.toFixed(2)}%`);
+if (percent < threshold) {
+  console.error(`Coverage threshold of ${threshold}% not met`);
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- run `npm run coverage` in CI
- add optional coverage threshold check
- upload coverage report as artifact

## Testing
- `npm test` *(fails: price overflow)*
- `npm run lint` *(fails: ESLint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6869591ba6a8833391d842e0666c3b89