### PR TITLE
Add price validation for subscription plans

### DIFF
--- a/contracts/BaseSubscription.sol
+++ b/contracts/BaseSubscription.sol
@@ -83,6 +83,9 @@ abstract contract BaseSubscription {
         require(_billingCycle > 0, "Billing cycle must be > 0");
         if (_priceInUsd) {
             require(_priceFeedAddress != address(0), "Price feed address required for USD pricing");
+            require(_usdPrice > 0, "USD price must be > 0");
+        } else {
+            require(_price > 0, "Token price must be > 0");
         }
         require(_token != address(0), "Token address cannot be zero");
 
@@ -121,6 +124,9 @@ abstract contract BaseSubscription {
 
         if (_priceInUsd) {
             require(_priceFeedAddress != address(0), "Price feed address required for USD pricing");
+            require(_usdPrice > 0, "USD price must be > 0");
+        } else {
+            require(_price > 0, "Token price must be > 0");
         }
 
         plan.billingCycle = _billingCycle;

--- a/test/Subscription.ts
+++ b/test/Subscription.ts
@@ -160,6 +160,36 @@ describe("Subscription Contract", function () {
                 ethers.constants.AddressZero
             )).to.be.revertedWith("Billing cycle must be > 0");
         });
+
+        it("Should revert if USD plan has zero usdPrice", async function () {
+            const { subscriptionContract, mockToken, owner, mockAggregator } = await loadFixture(deploySubscriptionFixture);
+            await expect(
+                subscriptionContract.connect(owner).createPlan(
+                    owner.address,
+                    mockToken.target,
+                    0,
+                    THIRTY_DAYS_IN_SECS,
+                    true,
+                    0,
+                    mockAggregator.target
+                )
+            ).to.be.revertedWith("USD price must be > 0");
+        });
+
+        it("Should revert if token priced plan has zero price", async function () {
+            const { subscriptionContract, mockToken, owner } = await loadFixture(deploySubscriptionFixture);
+            await expect(
+                subscriptionContract.connect(owner).createPlan(
+                    owner.address,
+                    mockToken.target,
+                    0,
+                    THIRTY_DAYS_IN_SECS,
+                    false,
+                    0,
+                    ethers.ZeroAddress
+                )
+            ).to.be.revertedWith("Token price must be > 0");
+        });
     });
 
     describe("updatePlan", function () {
@@ -237,6 +267,20 @@ describe("Subscription Contract", function () {
             await expect(
                 subscriptionContract.connect(owner).updatePlan(0, 0, 0, false, 0, ethers.constants.AddressZero)
             ).to.be.revertedWith("Billing cycle must be > 0");
+        });
+
+        it("Reverts when USD plan updated with zero usdPrice", async function () {
+            const { subscriptionContract, owner, mockAggregator } = await loadFixture(fixtureWithExistingPlan);
+            await expect(
+                subscriptionContract.connect(owner).updatePlan(0, THIRTY_DAYS_IN_SECS, 0, true, 0, mockAggregator.target)
+            ).to.be.revertedWith("USD price must be > 0");
+        });
+
+        it("Reverts when token plan updated with zero price", async function () {
+            const { subscriptionContract, owner } = await loadFixture(fixtureWithExistingPlan);
+            await expect(
+                subscriptionContract.connect(owner).updatePlan(0, THIRTY_DAYS_IN_SECS, 0, false, 0, ethers.ZeroAddress)
+            ).to.be.revertedWith("Token price must be > 0");
         });
 
         async function fixtureWithExistingUsdPlan() {


### PR DESCRIPTION
## Summary
- validate price parameters when creating or updating a plan
- add tests covering the new revert conditions

## Testing
- `npm test` *(fails: 86 failing)*

------
https://chatgpt.com/codex/tasks/task_e_686961811dec83338a4643a30d0186da