### PR TITLE
Enable strict mode and adjust Next build configs

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -34,6 +34,8 @@ jobs:
         working-directory: frontend
       - name: Build frontend
         run: npm run build
+        env:
+          NODE_ENV: production
         working-directory: frontend
       - name: Deploy to Vercel
         uses: amondnet/vercel-action@v25

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,6 +34,9 @@ services:
     command: sh -c "npm run build && npm start"
     env_file:
       - .env
+    environment:
+      - NODE_ENV=production
+      - NEXT_TELEMETRY_DISABLED=1
     depends_on:
       - hardhat
     ports:

--- a/frontend/lib/contract.ts
+++ b/frontend/lib/contract.ts
@@ -1,7 +1,7 @@
 import { ethers } from "ethers";
 import type { ExternalProvider } from "ethers";
-import type { Subscription } from "typechain/contracts/Subscription.sol/Subscription";
-import { Subscription__factory } from "typechain/factories/contracts/Subscription.sol/Subscription__factory";
+import type { Subscription } from "typechain/contracts/Subscription";
+import { Subscription__factory } from "typechain/factories/contracts/Subscription__factory";
 import { env } from "./env";
 
 /* eslint-disable @typescript-eslint/no-explicit-any */

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -1,7 +1,16 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  reactStrictMode: true,
+  async rewrites() {
+    return [{
+      source: '/:path*',
+      destination: '/index.html',
+    }];
+  },
+  experimental: {
+    externalDir: true,
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Summary
- enable React strict mode and allow reading code outside frontend
- rewrite all paths to `index.html`
- fix contract import paths
- update Docker compose and workflow for production builds

## Testing
- `npm run lint`
- `npm run build` *(fails: Module not found for typechain imports)*

------
https://chatgpt.com/codex/tasks/task_e_686982d336408333a18113363ff6bcef