### PR TITLE
Validate env vars on dev

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -42,6 +42,8 @@ Run the development server:
 npm run dev
 ```
 
+This command first validates `.env.local` via `scripts/check-env.js`.
+
 Open [http://localhost:3000](http://localhost:3000) to view the app.
 
 ## Pages

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev --turbopack",
+    "dev": "node scripts/check-env.js && next dev --turbopack",
     "prebuild": "node scripts/check-env.js",
     "build": "next build",
     "start": "next start",

--- a/frontend/scripts/check-env.js
+++ b/frontend/scripts/check-env.js
@@ -22,7 +22,8 @@ function check() {
   }
 }
 
-if (require.main === module) {
+// Validate the environment when called directly or via `npm run dev`
+if (require.main === module || process.env.npm_lifecycle_event === 'dev') {
   try {
     check();
   } catch (err) {


### PR DESCRIPTION
## Summary
- run env var validation for development start
- check `.env.local` when running `npm run dev`
- describe this check in the frontend README

## Testing
- `npm test` *(fails: hardhat not found)*

------
https://chatgpt.com/codex/tasks/task_e_686982d4c3508333a760ae114b155d92