### PR TITLE
Add Jest coverage and upload to workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,3 +43,14 @@ jobs:
         with:
           name: coverage-report
           path: coverage
+      - name: Install frontend dependencies
+        run: npm ci
+        working-directory: frontend
+      - name: Run frontend tests with coverage
+        run: npm test -- --coverage
+        working-directory: frontend
+      - name: Upload frontend coverage
+        uses: actions/upload-artifact@v4
+        with:
+          name: frontend-coverage
+          path: frontend/coverage

--- a/frontend/jest.config.js
+++ b/frontend/jest.config.js
@@ -3,6 +3,12 @@ module.exports = {
   testEnvironment: 'jsdom',
   testMatch: ['<rootDir>/__tests__/**/*.test.ts?(x)'],
   setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
+  coverage: true,
+  coverageThreshold: {
+    global: {
+      lines: 70,
+    },
+  },
   extensionsToTreatAsEsm: ['.ts', '.tsx'],
   moduleNameMapper: {
     '^(\.{1,2}/.*)\\.js$': '$1',


### PR DESCRIPTION
## Summary
- enable coverage for Jest tests in `frontend`
- run Jest with coverage in CI
- upload coverage artifact for `frontend`

## Testing
- `npm test` *(fails: hardhat not found)*
- `npm ci` *(fails: dependency conflict)*

------
https://chatgpt.com/codex/tasks/task_e_68699421d62c8333af580c37897155ec