### PR TITLE
Add GraphQL Codegen entity types

### DIFF
--- a/frontend/app/analytics/page.tsx
+++ b/frontend/app/analytics/page.tsx
@@ -1,25 +1,13 @@
 'use client';
 import { useEffect, useState } from 'react';
 import { getActiveSubscriptions, getPayments, getPlans } from '../../lib/subgraph';
+import type { Subscription, Payment, Plan } from '../../generated/graphql';
 
-interface SubscriptionData {
-  id: string;
-  user: string;
-  planId: string;
-  nextPaymentDate: string;
-}
-
-interface PaymentData {
-  id: string;
-  user: string;
-  planId: string;
-  amount: string;
-}
 
 export default function Analytics() {
-  const [subs, setSubs] = useState<SubscriptionData[]>([]);
-  const [payments, setPayments] = useState<PaymentData[]>([]);
-  const [plans, setPlans] = useState<{ id: string; totalPaid: string }[]>([]);
+  const [subs, setSubs] = useState<Subscription[]>([]);
+  const [payments, setPayments] = useState<Payment[]>([]);
+  const [plans, setPlans] = useState<Plan[]>([]);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
 

--- a/frontend/app/payment/page.tsx
+++ b/frontend/app/payment/page.tsx
@@ -1,9 +1,6 @@
 'use client';
 import { useState } from 'react';
-import {
-  getContract,
-  processPayment as contractProcessPayment,
-} from '../../lib/contract';
+import { processPayment as contractProcessPayment } from '../../lib/contract';
 import useWallet from '../../lib/useWallet';
 import { useStore } from '../../lib/store';
 

--- a/frontend/codegen.ts
+++ b/frontend/codegen.ts
@@ -1,0 +1,19 @@
+import type { CodegenConfig } from '@graphql-codegen/cli';
+
+const config: CodegenConfig = {
+  schema: './schema.graphql',
+  documents: ['./lib/subgraph.ts'],
+  config: {
+    scalars: {
+      BigInt: 'string',
+      Bytes: 'string',
+    },
+  },
+  generates: {
+    './generated/graphql.ts': {
+      plugins: ['typescript', 'typescript-operations'],
+    },
+  },
+};
+
+export default config;

--- a/frontend/generated/graphql.ts
+++ b/frontend/generated/graphql.ts
@@ -1,0 +1,86 @@
+export type Maybe<T> = T | null;
+export type InputMaybe<T> = Maybe<T>;
+export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> };
+export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Maybe<T[SubKey]> };
+export type MakeEmpty<T extends { [key: string]: unknown }, K extends keyof T> = { [_ in K]?: never };
+export type Incremental<T> = T | { [P in keyof T]?: P extends ' $fragmentName' | '__typename' ? T[P] : never };
+/** All built-in and custom scalars, mapped to their actual values */
+export type Scalars = {
+  ID: { input: string; output: string; }
+  String: { input: string; output: string; }
+  Boolean: { input: boolean; output: boolean; }
+  Int: { input: number; output: number; }
+  Float: { input: number; output: number; }
+  BigInt: { input: string; output: string; }
+  Bytes: { input: string; output: string; }
+};
+
+export enum OrderDirection {
+  Asc = 'asc',
+  Desc = 'desc'
+}
+
+export type Payment = {
+  __typename?: 'Payment';
+  amount: Scalars['BigInt']['output'];
+  id: Scalars['ID']['output'];
+  newNextPaymentDate: Scalars['BigInt']['output'];
+  planId: Scalars['BigInt']['output'];
+  user: Scalars['Bytes']['output'];
+};
+
+export enum Payment_OrderBy {
+  Id = 'id'
+}
+
+export type Plan = {
+  __typename?: 'Plan';
+  id: Scalars['ID']['output'];
+  totalPaid: Scalars['BigInt']['output'];
+};
+
+export type Query = {
+  __typename?: 'Query';
+  payments: Array<Payment>;
+  plans: Array<Plan>;
+  subscriptions: Array<Subscription>;
+};
+
+
+export type QueryPaymentsArgs = {
+  orderBy?: InputMaybe<Payment_OrderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+};
+
+
+export type QuerySubscriptionsArgs = {
+  where?: InputMaybe<Subscription_Filter>;
+};
+
+export type Subscription = {
+  __typename?: 'Subscription';
+  id: Scalars['ID']['output'];
+  nextPaymentDate?: Maybe<Scalars['BigInt']['output']>;
+  planId: Scalars['BigInt']['output'];
+  user: Scalars['Bytes']['output'];
+};
+
+export type Subscription_Filter = {
+  cancelled?: InputMaybe<Scalars['Boolean']['input']>;
+};
+
+export type ActiveSubscriptionsQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type ActiveSubscriptionsQuery = { __typename?: 'Query', subscriptions: Array<{ __typename?: 'Subscription', id: string, user: string, planId: string, nextPaymentDate?: string | null }> };
+
+export type PaymentsQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type PaymentsQuery = { __typename?: 'Query', payments: Array<{ __typename?: 'Payment', id: string, user: string, planId: string, amount: string, newNextPaymentDate: string }> };
+
+export type PlansQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type PlansQuery = { __typename?: 'Query', plans: Array<{ __typename?: 'Plan', id: string, totalPaid: string }> };

--- a/frontend/lib/subgraph.ts
+++ b/frontend/lib/subgraph.ts
@@ -1,4 +1,12 @@
 import { ApolloClient, InMemoryCache, gql } from '@apollo/client';
+import type {
+  ActiveSubscriptionsQuery,
+  PaymentsQuery,
+  PlansQuery,
+  Subscription,
+  Payment,
+  Plan,
+} from '../generated/graphql';
 import { env } from './env';
 
 const client = new ApolloClient({
@@ -38,18 +46,20 @@ export const PLANS_QUERY = gql`
   }
 `;
 
-export async function getActiveSubscriptions() {
-  const { data } = await client.query({ query: ACTIVE_SUBSCRIPTIONS_QUERY });
+export async function getActiveSubscriptions(): Promise<Subscription[]> {
+  const { data } = await client.query<ActiveSubscriptionsQuery>({
+    query: ACTIVE_SUBSCRIPTIONS_QUERY,
+  });
   return data.subscriptions;
 }
 
-export async function getPayments() {
-  const { data } = await client.query({ query: PAYMENTS_QUERY });
+export async function getPayments(): Promise<Payment[]> {
+  const { data } = await client.query<PaymentsQuery>({ query: PAYMENTS_QUERY });
   return data.payments;
 }
 
-export async function getPlans() {
-  const { data } = await client.query({ query: PLANS_QUERY });
+export async function getPlans(): Promise<Plan[]> {
+  const { data } = await client.query<PlansQuery>({ query: PLANS_QUERY });
   return data.plans;
 }
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,6 +6,7 @@
     "dev": "node scripts/check-env.js && next dev --turbopack",
     "prebuild": "node scripts/check-env.js",
     "build": "next build",
+    "codegen": "graphql-codegen --config codegen.ts",
     "start": "next start",
     "lint": "next lint",
     "test": "jest"
@@ -37,6 +38,9 @@
     "jest": "^29.7.0",
     "ts-jest": "^29.1.1",
     "typescript": "^5",
-    "zod": "^3.22.4"
+    "zod": "^3.22.4",
+    "@graphql-codegen/cli": "^5.0.7",
+    "@graphql-codegen/typescript": "^4.1.6",
+    "@graphql-codegen/typescript-operations": "^4.6.1"
   }
 }

--- a/frontend/schema.graphql
+++ b/frontend/schema.graphql
@@ -1,0 +1,41 @@
+scalar Bytes
+scalar BigInt
+
+input Subscription_filter {
+  cancelled: Boolean
+}
+
+enum OrderDirection {
+  asc
+  desc
+}
+
+enum Payment_orderBy {
+  id
+}
+
+type Plan {
+  id: ID!
+  totalPaid: BigInt!
+}
+
+type Subscription {
+  id: ID!
+  user: Bytes!
+  planId: BigInt!
+  nextPaymentDate: BigInt
+}
+
+type Payment {
+  id: ID!
+  user: Bytes!
+  planId: BigInt!
+  amount: BigInt!
+  newNextPaymentDate: BigInt!
+}
+
+type Query {
+  subscriptions(where: Subscription_filter): [Subscription!]!
+  payments(orderBy: Payment_orderBy, orderDirection: OrderDirection): [Payment!]!
+  plans: [Plan!]!
+}

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -23,6 +23,6 @@
       "typechain": ["../typechain"]
     }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts", "../typechain/**/*.ts"],
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts", "../typechain/**/*.ts", "generated/**/*.ts"],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
## Summary
- generate GraphQL types for subgraph entities
- use generated types in subgraph client
- update analytics page to use new types
- add GraphQL Codegen config and schema

## Testing
- `npm run lint`
- `npm test` in `frontend`
- `npm test` *(fails: Hardhat tests)*

------
https://chatgpt.com/codex/tasks/task_e_686994202eb48333bb0ac1c39e5ef8a5