### PR TITLE
Add development stack helper

### DIFF
--- a/docs/Todo-fuer-User.md
+++ b/docs/Todo-fuer-User.md
@@ -1,0 +1,9 @@
+# Todo für User
+
+Mit `npm run devstack` lässt sich die komplette Entwicklungsumgebung starten. Das Skript ruft Hardhat, den Subgraph-Server und das Frontend parallel über `concurrently` auf.
+
+```bash
+npm run devstack
+```
+
+Beende alle Prozesse gemeinsam mit `Ctrl+C`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
         "@chainlink/contracts": "^1.4.0",
         "@openzeppelin/contracts": "^4.9.3",
         "pino": "^9.7.0",
-        "pino-loki": "^2.6.0"
+        "pino-loki": "^2.6.0",
+        "prom-client": "^14.1.0"
       },
       "devDependencies": {
         "@graphprotocol/graph-cli": "^0.97.1",
@@ -30,6 +31,7 @@
         "@types/node": "^24.0.7",
         "@typescript-eslint/eslint-plugin": "^8.35.1",
         "@typescript-eslint/parser": "^8.35.1",
+        "concurrently": "^9.2.0",
         "dotenv": "^17.0.1",
         "eslint": "^9.30.0",
         "ethers": "^6.15.0",
@@ -6325,6 +6327,12 @@
         "wasm-opt": "bin/wasm-opt"
       }
     },
+    "node_modules/bintrees": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.2.tgz",
+      "integrity": "sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==",
+      "license": "MIT"
+    },
     "node_modules/blakejs": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.2.1.tgz",
@@ -7217,6 +7225,66 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "license": "MIT"
+    },
+    "node_modules/concurrently": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-9.2.0.tgz",
+      "integrity": "sha512-IsB/fiXTupmagMW4MNp2lx2cdSN2FfZq78vF90LBB+zZHArbIQZjQtzXCiXnvTxCZSvXanTqFLWBjw2UkLx1SQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.2",
+        "lodash": "^4.17.21",
+        "rxjs": "^7.8.1",
+        "shell-quote": "^1.8.1",
+        "supports-color": "^8.1.1",
+        "tree-kill": "^1.2.2",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "conc": "dist/bin/concurrently.js",
+        "concurrently": "dist/bin/concurrently.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/open-cli-tools/concurrently?sponsor=1"
+      }
+    },
+    "node_modules/concurrently/node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/concurrently/node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/config-chain": {
       "version": "1.1.13",
@@ -15101,6 +15169,18 @@
       "dev": true,
       "license": "Apache-2.0 OR MIT"
     },
+    "node_modules/prom-client": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-14.2.0.tgz",
+      "integrity": "sha512-sF308EhTenb/pDRPakm+WgiN+VdM/T1RaHj1x+MvAuT8UiQP8JmOEbxVqtkbfR4LrvOg5n7ic01kRBDGXjYikA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tdigest": "^0.1.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/prompts": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
@@ -15748,6 +15828,16 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/rxjs": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
     "node_modules/safe-array-concat": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.3.tgz",
@@ -16161,6 +16251,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/shell-quote": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
+      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/shelljs": {
@@ -17230,6 +17333,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/tdigest": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.2.tgz",
+      "integrity": "sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==",
+      "license": "MIT",
+      "dependencies": {
+        "bintrees": "1.0.2"
+      }
+    },
     "node_modules/term-size": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/term-size/-/term-size-2.2.1.tgz",
@@ -17379,6 +17491,16 @@
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
       "license": "MIT"
+    },
+    "node_modules/tree-kill": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "tree-kill": "cli.js"
+      }
     },
     "node_modules/ts-api-utils": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "ts-node": "^10.9.2",
     "typechain": "^8.3.2",
     "typescript": "^5.4.5",
-    "zod": "^3.25.73"
+    "zod": "^3.25.73",
+    "concurrently": "^9.2.0"
   },
   "scripts": {
     "compile": "hardhat compile",
@@ -56,7 +57,8 @@
     "coverage-check": "node scripts/check-coverage.js",
     "slither": "slither .",
     "test-subgraph": "graph test",
-    "test:e2e": "playwright test"
+    "test:e2e": "playwright test",
+    "devstack": "node scripts/start-dev.ts"
   },
   "dependencies": {
     "@chainlink/contracts": "^1.4.0",

--- a/scripts/start-dev.ts
+++ b/scripts/start-dev.ts
@@ -1,0 +1,13 @@
+#!/usr/bin/env node
+const { concurrently } = require('concurrently');
+
+concurrently(
+  [
+    { command: 'npx hardhat node', name: 'hardhat', prefixColor: 'blue' },
+    { command: 'npm run subgraph-server', name: 'subgraph', prefixColor: 'magenta' },
+    { command: 'npm --prefix frontend run dev', name: 'frontend', prefixColor: 'green' },
+  ],
+  {
+    killOthers: ['failure', 'success'],
+  }
+).result.catch(() => process.exit(1));


### PR DESCRIPTION
## Summary
- add new `start-dev.ts` script that starts Hardhat, subgraph server and frontend concurrently
- expose script as `npm run devstack`
- document usage in `docs/Todo-fuer-User.md`
- add concurrently to dev dependencies

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6869941ca2688333bdc4cf4c09fd933f