### PR TITLE
Add MerchantUpdated subgraph handler

### DIFF
--- a/subgraph/src/mapping.ts
+++ b/subgraph/src/mapping.ts
@@ -2,6 +2,7 @@ import {
   PlanCreated,
   PlanUpdated,
   PlanDisabled,
+  MerchantUpdated,
   Subscribed,
   PaymentProcessed,
   SubscriptionCancelled
@@ -39,6 +40,13 @@ export function handlePlanDisabled(event: PlanDisabled): void {
   let plan = Plan.load(event.params.planId.toString())
   if (!plan) return
   plan.active = false
+  plan.save()
+}
+
+export function handleMerchantUpdated(event: MerchantUpdated): void {
+  let plan = Plan.load(event.params.planId.toString())
+  if (!plan) return
+  plan.merchant = event.params.newMerchant
   plan.save()
 }
 

--- a/subgraph/subgraph.yaml
+++ b/subgraph/subgraph.yaml
@@ -27,6 +27,8 @@ dataSources:
           handler: handlePlanUpdated
         - event: PlanDisabled(uint256)
           handler: handlePlanDisabled
+        - event: MerchantUpdated(uint256,address,address)
+          handler: handleMerchantUpdated
         - event: Subscribed(address,uint256,uint256)
           handler: handleSubscribed
         - event: PaymentProcessed(address,uint256,uint256,uint256)

--- a/subgraph/tests/integration.test.ts
+++ b/subgraph/tests/integration.test.ts
@@ -211,7 +211,8 @@ describe('Subgraph integration', function () {
     await adminContract.upgrade(await proxyDeploy.getAddress(), await impl2.getAddress());
     subscription = new ethers.Contract(await proxyDeploy.getAddress(), subV2Json.abi, ownerSigner);
 
-    await subscription.connect(ownerSigner).processPayment(user, 0);
+    await subscription.connect(ownerSigner).updateMerchant(0, user);
+    await subscription.connect(userSigner).processPayment(user, 0);
 
     process.env.NETWORK = 'hardhat';
     process.env.CONTRACT_ADDRESS = await subscription.getAddress();
@@ -242,7 +243,7 @@ describe('Subgraph integration', function () {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           query:
-            '{ plans { id totalPaid } subscriptions { id } payments { id planId amount } }',
+            '{ plans { id totalPaid merchant } subscriptions { id } payments { id planId amount } }',
         }),
       },
     );
@@ -252,5 +253,6 @@ describe('Subgraph integration', function () {
     expect(json.data.plans[0].totalPaid).to.equal(
       ethers.parseUnits('1', 18).toString(),
     );
+    expect(json.data.plans[0].merchant).to.equal(user.toLowerCase());
   });
 });


### PR DESCRIPTION
## Summary
- support `MerchantUpdated` event in the subgraph
- update integration and mapping tests for new event

## Testing
- `npm run test` *(fails: price overflow, others)*
- `npm run test-subgraph` *(fails: TypeError: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_68699417d0d08333a53a77565ec8011c