### PR TITLE
Add Hardhat tasks for plan management

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -4,6 +4,10 @@ import '@nomicfoundation/hardhat-verify';
 import '@openzeppelin/hardhat-upgrades';
 import '@typechain/hardhat';
 import 'hardhat-gas-reporter';
+import './tasks/create-plan';
+import './tasks/update-plan';
+import './tasks/pause';
+import './tasks/disable-plan';
 
 import path from 'path';
 import * as dotenv from 'dotenv';

--- a/tasks/create-plan.ts
+++ b/tasks/create-plan.ts
@@ -1,0 +1,55 @@
+import { task, types } from 'hardhat/config';
+import { HardhatRuntimeEnvironment } from 'hardhat/types';
+
+/**
+ * Creates a new subscription plan on an existing Subscription contract.
+ *
+ * Example:
+ * npx hardhat create-plan --network hardhat \
+ *   --subscription 0xSUB --merchant 0xMERCHANT --token 0xTOKEN \
+ *   --price 1000 --billing-cycle 3600 --price-in-usd \
+ *   --usd-price 999 --price-feed 0xFEED
+ */
+
+task('create-plan', 'Create a new subscription plan')
+  .addOptionalParam('subscription', 'Subscription contract address')
+  .addOptionalParam('merchant', 'Merchant address')
+  .addOptionalParam('token', 'ERC20 token address')
+  .addOptionalParam('price', 'Token price', undefined, types.string)
+  .addOptionalParam('billingCycle', 'Billing cycle in seconds', undefined, types.string)
+  .addFlag('priceInUsd', 'Price denominated in USD')
+  .addOptionalParam('usdPrice', 'USD price (cents)', undefined, types.string)
+  .addOptionalParam('priceFeed', 'Chainlink price feed address')
+  .setAction(async (args: any, hre: HardhatRuntimeEnvironment) => {
+    const subscription = args.subscription ?? process.env.SUBSCRIPTION_ADDRESS;
+    if (!subscription) throw new Error('subscription address missing');
+    const [signer] = await hre.ethers.getSigners();
+    const merchant = args.merchant ?? process.env.MERCHANT_ADDRESS ?? signer.address;
+    const token = args.token ?? process.env.TOKEN_ADDRESS;
+    if (!token) throw new Error('token address missing');
+    const price = args.price ?? process.env.FIXED_PRICE ?? '0';
+    const billingCycle = BigInt(args.billingCycle ?? process.env.BILLING_CYCLE ?? '0');
+    const priceInUsd = args.priceInUsd ? true : process.env.PRICE_IN_USD === 'true';
+    const usdPrice = BigInt(args.usdPrice ?? process.env.USD_PRICE ?? '0');
+    const priceFeed = args.priceFeed ?? process.env.PRICE_FEED ?? hre.ethers.ZeroAddress;
+
+    const contract = await hre.ethers.getContractAt(
+      'SubscriptionUpgradeable',
+      subscription,
+      signer,
+    );
+
+    const tx = await contract.createPlan(
+      merchant,
+      token,
+      price,
+      billingCycle,
+      priceInUsd,
+      usdPrice,
+      priceFeed,
+    );
+    await tx.wait();
+    console.log(`Plan created with tx ${tx.hash}`);
+  });
+
+export {};

--- a/tasks/disable-plan.ts
+++ b/tasks/disable-plan.ts
@@ -1,0 +1,25 @@
+import { task, types } from 'hardhat/config';
+import { HardhatRuntimeEnvironment } from 'hardhat/types';
+
+/**
+ * Disables a subscription plan so no new subscriptions can be made.
+ *
+ * Example:
+ * npx hardhat disable-plan --network hardhat --subscription 0xSUB --plan-id 0
+ */
+
+task('disable-plan', 'Disable a subscription plan')
+  .addOptionalParam('subscription', 'Subscription contract address')
+  .addOptionalParam('planId', 'Plan ID', undefined, types.string)
+  .setAction(async (args: any, hre: HardhatRuntimeEnvironment) => {
+    const subscription = args.subscription ?? process.env.SUBSCRIPTION_ADDRESS;
+    if (!subscription) throw new Error('subscription address missing');
+    const planId = BigInt(args.planId ?? process.env.PLAN_ID ?? '0');
+    const [signer] = await hre.ethers.getSigners();
+    const contract = await hre.ethers.getContractAt('SubscriptionUpgradeable', subscription, signer);
+    const tx = await contract.disablePlan(planId);
+    await tx.wait();
+    console.log(`Plan ${planId} disabled with tx ${tx.hash}`);
+  });
+
+export {};

--- a/tasks/pause.ts
+++ b/tasks/pause.ts
@@ -1,0 +1,35 @@
+import { task } from 'hardhat/config';
+import { HardhatRuntimeEnvironment } from 'hardhat/types';
+
+/**
+ * Pauses subscription related functions on the contract.
+ *
+ * Example:
+ * npx hardhat pause --network hardhat --subscription 0xSUB
+ */
+
+task('pause', 'Pause the subscription contract')
+  .addOptionalParam('subscription', 'Subscription contract address')
+  .setAction(async (args: any, hre: HardhatRuntimeEnvironment) => {
+    const subscription = args.subscription ?? process.env.SUBSCRIPTION_ADDRESS;
+    if (!subscription) throw new Error('subscription address missing');
+    const [signer] = await hre.ethers.getSigners();
+    const contract = await hre.ethers.getContractAt('SubscriptionUpgradeable', subscription, signer);
+    const tx = await contract.pause();
+    await tx.wait();
+    console.log(`Contract paused with tx ${tx.hash}`);
+  });
+
+task('unpause', 'Unpause the subscription contract')
+  .addOptionalParam('subscription', 'Subscription contract address')
+  .setAction(async (args: any, hre: HardhatRuntimeEnvironment) => {
+    const subscription = args.subscription ?? process.env.SUBSCRIPTION_ADDRESS;
+    if (!subscription) throw new Error('subscription address missing');
+    const [signer] = await hre.ethers.getSigners();
+    const contract = await hre.ethers.getContractAt('SubscriptionUpgradeable', subscription, signer);
+    const tx = await contract.unpause();
+    await tx.wait();
+    console.log(`Contract unpaused with tx ${tx.hash}`);
+  });
+
+export {};

--- a/tasks/update-plan.ts
+++ b/tasks/update-plan.ts
@@ -1,0 +1,37 @@
+import { task, types } from 'hardhat/config';
+import { HardhatRuntimeEnvironment } from 'hardhat/types';
+
+/**
+ * Updates an existing subscription plan.
+ *
+ * Example:
+ * npx hardhat update-plan --network hardhat \
+ *   --subscription 0xSUB --plan-id 0 --billing-cycle 7200 \
+ *   --price 2000 --price-in-usd --usd-price 999 --price-feed 0xFEED
+ */
+
+task('update-plan', 'Update an existing subscription plan')
+  .addOptionalParam('subscription', 'Subscription contract address')
+  .addOptionalParam('planId', 'Plan ID', undefined, types.string)
+  .addOptionalParam('billingCycle', 'Billing cycle in seconds', undefined, types.string)
+  .addOptionalParam('price', 'Token price', undefined, types.string)
+  .addFlag('priceInUsd', 'Price denominated in USD')
+  .addOptionalParam('usdPrice', 'USD price (cents)', undefined, types.string)
+  .addOptionalParam('priceFeed', 'Chainlink price feed address')
+  .setAction(async (args: any, hre: HardhatRuntimeEnvironment) => {
+    const subscription = args.subscription ?? process.env.SUBSCRIPTION_ADDRESS;
+    if (!subscription) throw new Error('subscription address missing');
+    const planId = BigInt(args.planId ?? process.env.PLAN_ID ?? '0');
+    const billingCycle = BigInt(args.billingCycle ?? process.env.BILLING_CYCLE ?? '0');
+    const price = args.price ?? process.env.FIXED_PRICE ?? '0';
+    const priceInUsd = args.priceInUsd ? true : process.env.PRICE_IN_USD === 'true';
+    const usdPrice = BigInt(args.usdPrice ?? process.env.USD_PRICE ?? '0');
+    const priceFeed = args.priceFeed ?? process.env.PRICE_FEED ?? hre.ethers.ZeroAddress;
+    const [signer] = await hre.ethers.getSigners();
+    const contract = await hre.ethers.getContractAt('SubscriptionUpgradeable', subscription, signer);
+    const tx = await contract.updatePlan(planId, billingCycle, price, priceInUsd, usdPrice, priceFeed);
+    await tx.wait();
+    console.log(`Plan ${planId} updated with tx ${tx.hash}`);
+  });
+
+export {};

--- a/test/tasks.ts
+++ b/test/tasks.ts
@@ -1,0 +1,62 @@
+import { expect } from 'chai';
+import { ethers, upgrades, run } from 'hardhat';
+import { loadFixture } from '@nomicfoundation/hardhat-network-helpers';
+import type { SubscriptionUpgradeable, MockToken } from '../typechain';
+
+async function deployFixture() {
+  const [owner] = await ethers.getSigners();
+  const Token = await ethers.getContractFactory('MockToken', owner);
+  const token = (await Token.deploy('Mock', 'MOCK', 18)) as MockToken;
+  await token.waitForDeployment();
+  const Sub = await ethers.getContractFactory('SubscriptionUpgradeable', owner);
+  const proxy = (await upgrades.deployProxy(Sub, [owner.address], {
+    initializer: 'initialize',
+  })) as SubscriptionUpgradeable;
+  await proxy.waitForDeployment();
+  return { owner, token, proxy };
+}
+
+describe('Hardhat tasks', function () {
+  it('runs create/update/pause/unpause/disable tasks', async function () {
+    const { owner, token, proxy } = await loadFixture(deployFixture);
+    const addr = await proxy.getAddress();
+
+    await run('create-plan', {
+      subscription: addr,
+      merchant: owner.address,
+      token: token.target,
+      price: '100',
+      billingCycle: '60',
+      priceInUsd: false,
+      usdPrice: '0',
+      priceFeed: ethers.ZeroAddress,
+    });
+
+    let plan = await proxy.plans(0);
+    expect(plan.merchant).to.equal(owner.address);
+
+    await run('update-plan', {
+      subscription: addr,
+      planId: '0',
+      billingCycle: '120',
+      price: '200',
+      priceInUsd: false,
+      usdPrice: '0',
+      priceFeed: ethers.ZeroAddress,
+    });
+
+    plan = await proxy.plans(0);
+    expect(plan.billingCycle).to.equal(120n);
+    expect(plan.price).to.equal(200n);
+
+    await run('pause', { subscription: addr });
+    expect(await proxy.paused()).to.equal(true);
+
+    await run('unpause', { subscription: addr });
+    expect(await proxy.paused()).to.equal(false);
+
+    await run('disable-plan', { subscription: addr, planId: '0' });
+    plan = await proxy.plans(0);
+    expect(plan.active).to.equal(false);
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,6 @@
     "skipLibCheck": true,
     "resolveJsonModule": true
   },
-  "include": ["./scripts", "./test", "./typechain", "./hardhat.config.ts"],
+  "include": ["./scripts", "./tasks", "./test", "./typechain", "./hardhat.config.ts"],
   "files": ["./hardhat.config.ts"]
 }


### PR DESCRIPTION
## Summary
- implement new Hardhat tasks for creating, updating and disabling plans and for pausing/unpausing the contract
- load these tasks in Hardhat config and include the tasks folder in tsconfig
- provide unit test exercising the tasks on the hardhat network

## Testing
- `npm test` *(fails: 89 failing)*
- `npx hardhat test test/tasks.ts`

------
https://chatgpt.com/codex/tasks/task_e_6869941b79b0833398cc7dc6ce6fec36