### PR TITLE
Add plan details and filtering

### DIFF
--- a/frontend/__tests__/ManagePlans.test.tsx
+++ b/frontend/__tests__/ManagePlans.test.tsx
@@ -30,8 +30,21 @@ function Wrapper() {
 }
 
 describe('ManagePlans page', () => {
+  const plan = {
+    id: 0n,
+    merchant: '0x',
+    token: 'a',
+    tokenDecimals: 18n,
+    price: 1n,
+    billingCycle: 1n,
+    priceInUsd: false,
+    usdPrice: 0n,
+    priceFeedAddress: '0x',
+    active: true,
+  };
+
   test('validates billing input', async () => {
-    mockUsePlans.mockReturnValue({ plans: [{}], reload: jest.fn() });
+    mockUsePlans.mockReturnValue({ plans: [plan], reload: jest.fn() });
     render(<Wrapper />);
     await userEvent.selectOptions(screen.getByRole('combobox'), ['0']);
     await userEvent.click(screen.getByText('Update'));
@@ -40,7 +53,7 @@ describe('ManagePlans page', () => {
   });
 
   test('shows contract error', async () => {
-    mockUsePlans.mockReturnValue({ plans: [{}], reload: jest.fn() });
+    mockUsePlans.mockReturnValue({ plans: [plan], reload: jest.fn() });
     mockUpdate.mockRejectedValue(new Error('boom'));
     render(<Wrapper />);
     await userEvent.selectOptions(screen.getByRole('combobox'), ['0']);
@@ -50,7 +63,7 @@ describe('ManagePlans page', () => {
   });
 
   test('validates merchant address', async () => {
-    mockUsePlans.mockReturnValue({ plans: [{}], reload: jest.fn() });
+    mockUsePlans.mockReturnValue({ plans: [plan], reload: jest.fn() });
     render(<Wrapper />);
     await userEvent.selectOptions(screen.getByRole('combobox'), ['0']);
     await userEvent.type(screen.getByLabelText('Merchant'), 'foo');
@@ -62,7 +75,7 @@ describe('ManagePlans page', () => {
   });
 
   test('shows update merchant error', async () => {
-    mockUsePlans.mockReturnValue({ plans: [{}], reload: jest.fn() });
+    mockUsePlans.mockReturnValue({ plans: [plan], reload: jest.fn() });
     mockUpdateMerchant.mockRejectedValue(new Error('fail'));
     render(<Wrapper />);
     await userEvent.selectOptions(screen.getByRole('combobox'), ['0']);
@@ -75,7 +88,7 @@ describe('ManagePlans page', () => {
   });
 
   test('disable plan button calls contract', async () => {
-    mockUsePlans.mockReturnValue({ plans: [{}], reload: jest.fn() });
+    mockUsePlans.mockReturnValue({ plans: [plan], reload: jest.fn() });
     render(<Wrapper />);
     await userEvent.selectOptions(screen.getByRole('combobox'), ['0']);
     await userEvent.click(screen.getByText('Plan deaktivieren'));

--- a/frontend/__tests__/PlansPage.test.tsx
+++ b/frontend/__tests__/PlansPage.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import Plans from '../app/plans/page';
 import { StoreProvider } from '../lib/store';
 
@@ -15,14 +16,28 @@ function Wrapper() {
 }
 
 describe('Plans page', () => {
-  test('renders list of plans', () => {
+  test('renders list of plans and shows details', async () => {
     mockUsePlans.mockReturnValue({
       plans: [
-        { merchant: '0x', token: 'a', tokenDecimals: 18n, price: 1n, billingCycle: 1n, priceInUsd: false, usdPrice: 0n, priceFeedAddress: '0x' },
+        {
+          id: 0n,
+          merchant: '0x',
+          token: 'a',
+          tokenDecimals: 18n,
+          price: 1n,
+          billingCycle: 1n,
+          priceInUsd: false,
+          usdPrice: 0n,
+          priceFeedAddress: '0x',
+          active: true,
+        },
       ],
       reload: jest.fn(),
     });
     render(<Wrapper />);
-    expect(screen.getByText(/Plan 0/)).toBeInTheDocument();
+    const btn = screen.getByText(/Plan 0/);
+    expect(btn).toBeInTheDocument();
+    await userEvent.click(btn);
+    expect(await screen.findByTestId('plan-details')).toBeInTheDocument();
   });
 });

--- a/frontend/__tests__/plansStore.test.tsx
+++ b/frontend/__tests__/plansStore.test.tsx
@@ -8,6 +8,7 @@ const mockedGetContract = getContract as jest.Mock;
 
 function makePlan(token: string): Plan {
   return {
+    id: 0n,
     merchant: '0x',
     token,
     tokenDecimals: 18n,
@@ -16,6 +17,7 @@ function makePlan(token: string): Plan {
     priceInUsd: false,
     usdPrice: 0n,
     priceFeedAddress: '0x',
+    active: true,
   };
 }
 

--- a/frontend/app/payment/page.tsx
+++ b/frontend/app/payment/page.tsx
@@ -1,9 +1,6 @@
 'use client';
 import { useState } from 'react';
-import {
-  getContract,
-  processPayment as contractProcessPayment,
-} from '../../lib/contract';
+import { processPayment as contractProcessPayment } from '../../lib/contract';
 import useWallet from '../../lib/useWallet';
 import { useStore } from '../../lib/store';
 

--- a/frontend/app/plans/page.tsx
+++ b/frontend/app/plans/page.tsx
@@ -8,6 +8,19 @@ export default function Plans() {
   const { plans } = usePlans();
   const [loading] = useState(false);
   const [error] = useState<string | null>(null);
+  const [selected, setSelected] = useState<bigint | null>(null);
+  const [filter, setFilter] = useState<'all' | 'active' | 'inactive'>('all');
+  const [sort, setSort] = useState<'asc' | 'desc'>('asc');
+
+  const filtered = plans.filter((p) =>
+    filter === 'all' ? true : filter === 'active' ? p.active : !p.active,
+  );
+  const sorted = [...filtered].sort((a, b) => {
+    const ap = Number(a.price);
+    const bp = Number(b.price);
+    return sort === 'asc' ? ap - bp : bp - ap;
+  });
+  const detail = selected !== null ? plans.find((p) => p.id === selected) : null;
 
   return (
     <div>
@@ -19,13 +32,51 @@ export default function Plans() {
         <a href="/plans/create">Create Plan</a> |{' '}
         <a href="/plans/manage">Manage Plans</a>
       </div>
+      <label htmlFor="filter">Filter</label>
+      <select
+        id="filter"
+        value={filter}
+        onChange={(e) =>
+          setFilter(e.target.value as 'all' | 'active' | 'inactive')
+        }
+        style={{ marginLeft: 4, marginRight: 10 }}
+      >
+        <option value="all">Alle</option>
+        <option value="active">Aktiv</option>
+        <option value="inactive">Inaktiv</option>
+      </select>
+      <label htmlFor="sort">Sortierung</label>
+      <select
+        id="sort"
+        value={sort}
+        onChange={(e) => setSort(e.target.value as 'asc' | 'desc')}
+        style={{ marginLeft: 4 }}
+      >
+        <option value="asc">Preis aufsteigend</option>
+        <option value="desc">Preis absteigend</option>
+      </select>
       <ul className="list">
-        {plans.map((p, idx) => (
-          <li key={idx}>
-            Plan {idx}: token {p.token} price {p.price.toString()} billing {p.billingCycle.toString()}s
+        {sorted.map((p) => (
+          <li key={p.id.toString()}>
+            <button onClick={() => setSelected(p.id)}>
+              Plan {p.id.toString()}: token {p.token} price {p.price.toString()} billing {p.billingCycle.toString()}s {p.active ? '(active)' : '(inactive)'}
+            </button>
           </li>
         ))}
       </ul>
+      {detail && (
+        <div data-testid="plan-details">
+          <h2>Plan Details</h2>
+          <ul className="list">
+            <li>ID: {detail.id.toString()}</li>
+            <li>Merchant: {detail.merchant}</li>
+            <li>Token: {detail.token}</li>
+            <li>Price: {detail.price.toString()}</li>
+            <li>Billing: {detail.billingCycle.toString()}s</li>
+            <li>Active: {detail.active ? 'true' : 'false'}</li>
+          </ul>
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/lib/plansStore.tsx
+++ b/frontend/lib/plansStore.tsx
@@ -3,6 +3,7 @@ import { createContext, useContext, useEffect, useState } from 'react';
 import { getContract } from './contract';
 
 export interface Plan {
+  id: bigint;
   merchant: string;
   token: string;
   tokenDecimals: bigint;
@@ -11,6 +12,7 @@ export interface Plan {
   priceInUsd: boolean;
   usdPrice: bigint;
   priceFeedAddress: string;
+  active: boolean;
 }
 
 interface PlansState {
@@ -30,7 +32,7 @@ export function PlansProvider({ children }: { children: React.ReactNode }) {
       const list: Plan[] = [];
       for (let i = 0n; i < nextId; i++) {
         const p = await contract.plans(i);
-        list.push(p as Plan);
+        list.push({ id: i, ...(p as Plan) });
       }
       setPlans(list);
     } catch (err) {


### PR DESCRIPTION
## Summary
- extend plan store with `id` and `active`
- add detail view, filtering and sorting to plans page
- fix unused import
- update tests

## Testing
- `npx next lint`
- `npm test` *(fails: Cannot find module '../generated/graphql' in subgraph tests)*

------
https://chatgpt.com/codex/tasks/task_e_68699eeb49e88333852c08e108360540