### PR TITLE
Add CLI commands for pause & merchant updates

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -8,6 +8,7 @@ import './tasks/create-plan';
 import './tasks/update-plan';
 import './tasks/pause';
 import './tasks/disable-plan';
+import './tasks/update-merchant';
 
 import path from 'path';
 import * as dotenv from 'dotenv';

--- a/scripts/cli.ts
+++ b/scripts/cli.ts
@@ -63,6 +63,26 @@ async function updatePlan(opts: any) {
   await run('update-plan', opts);
 }
 
+async function pauseContract(opts: any) {
+  const { run } = await loadHardhat();
+  await run('pause', opts);
+}
+
+async function unpauseContract(opts: any) {
+  const { run } = await loadHardhat();
+  await run('unpause', opts);
+}
+
+async function disablePlan(opts: any) {
+  const { run } = await loadHardhat();
+  await run('disable-plan', opts);
+}
+
+async function updateMerchant(opts: any) {
+  const { run } = await loadHardhat();
+  await run('update-merchant', opts);
+}
+
 const program = new Command();
 program
   .name('supscript-cli')
@@ -107,6 +127,33 @@ program
     usdPrice: opts.usdPrice,
     priceFeed: opts.priceFeed,
   }));
+
+program
+  .command('pause')
+  .description('Pause the subscription contract')
+  .option('-s, --subscription <address>', 'Subscription contract address')
+  .action((opts) => pauseContract(opts));
+
+program
+  .command('unpause')
+  .description('Unpause the subscription contract')
+  .option('-s, --subscription <address>', 'Subscription contract address')
+  .action((opts) => unpauseContract(opts));
+
+program
+  .command('disable')
+  .description('Disable a subscription plan')
+  .option('-s, --subscription <address>', 'Subscription contract address')
+  .option('-i, --plan-id <id>', 'Plan ID')
+  .action((opts) => disablePlan(opts));
+
+program
+  .command('update-merchant')
+  .description('Update the merchant of a plan')
+  .option('-s, --subscription <address>', 'Subscription contract address')
+  .option('-i, --plan-id <id>', 'Plan ID')
+  .option('-m, --merchant <address>', 'New merchant address')
+  .action((opts) => updateMerchant(opts));
 
 program.parseAsync().catch((err) => {
   console.error(err);

--- a/tasks/update-merchant.ts
+++ b/tasks/update-merchant.ts
@@ -1,0 +1,28 @@
+import { task, types } from 'hardhat/config';
+import { HardhatRuntimeEnvironment } from 'hardhat/types';
+
+/**
+ * Updates the merchant address for a subscription plan.
+ *
+ * Example:
+ * npx hardhat update-merchant --network hardhat --subscription 0xSUB --plan-id 0 --merchant 0xNEW
+ */
+
+task('update-merchant', 'Update the merchant of a subscription plan')
+  .addOptionalParam('subscription', 'Subscription contract address')
+  .addOptionalParam('planId', 'Plan ID', undefined, types.string)
+  .addOptionalParam('merchant', 'New merchant address')
+  .setAction(async (args: any, hre: HardhatRuntimeEnvironment) => {
+    const subscription = args.subscription ?? process.env.SUBSCRIPTION_ADDRESS;
+    if (!subscription) throw new Error('subscription address missing');
+    const planId = BigInt(args.planId ?? process.env.PLAN_ID ?? '0');
+    const merchant = args.merchant ?? process.env.MERCHANT_ADDRESS;
+    if (!merchant) throw new Error('merchant address missing');
+    const [signer] = await hre.ethers.getSigners();
+    const contract = await hre.ethers.getContractAt('SubscriptionUpgradeable', subscription, signer);
+    const tx = await contract.updateMerchant(planId, merchant);
+    await tx.wait();
+    console.log(`Merchant for plan ${planId} updated with tx ${tx.hash}`);
+  });
+
+export {};

--- a/test/tasks.ts
+++ b/test/tasks.ts
@@ -59,4 +59,30 @@ describe('Hardhat tasks', function () {
     plan = await proxy.plans(0);
     expect(plan.active).to.equal(false);
   });
+
+  it('runs update-merchant task', async function () {
+    const { owner, token, proxy } = await loadFixture(deployFixture);
+    const [, newMerchant] = await ethers.getSigners();
+    const addr = await proxy.getAddress();
+
+    await run('create-plan', {
+      subscription: addr,
+      merchant: owner.address,
+      token: token.target,
+      price: '100',
+      billingCycle: '60',
+      priceInUsd: false,
+      usdPrice: '0',
+      priceFeed: ethers.ZeroAddress,
+    });
+
+    await run('update-merchant', {
+      subscription: addr,
+      planId: '0',
+      merchant: newMerchant.address,
+    });
+
+    const plan = await proxy.plans(0);
+    expect(plan.merchant).to.equal(newMerchant.address);
+  });
 });


### PR DESCRIPTION
## Summary
- extend CLI with pause, unpause, disable and update-merchant commands
- add Hardhat task `update-merchant`
- register new task in `hardhat.config.ts`
- test additional task execution

## Testing
- `npm test` *(fails: price overflow, insufficient allowance, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6869aa65fe38833395e9fdfdc7c28b6b