### PR TITLE
Handle SIGINT in subgraph server

### DIFF
--- a/docs/Todo-fuer-User.md
+++ b/docs/Todo-fuer-User.md
@@ -7,3 +7,4 @@ npm run devstack
 ```
 
 Beende alle Prozesse gemeinsam mit `Ctrl+C`.
+Der Subgraph-Server beendet dabei jetzt auch `graph-node` sauber.

--- a/scripts/subgraph-server.test.ts
+++ b/scripts/subgraph-server.test.ts
@@ -1,10 +1,10 @@
 import { expect } from 'chai';
-import { spawnSync } from 'child_process';
+import { spawn, spawnSync } from 'child_process';
 import fs from 'fs';
 
 it('exits when graph-node fails to spawn', function () {
   const logFile = 'subgraph-server.test.log';
-  const res = spawnSync('node', ['scripts/subgraph-server.ts'], {
+  const res = spawnSync('node', ['-r', 'ts-node/register/transpile-only', 'scripts/subgraph-server.ts'], {
     env: {
       ...process.env,
       GRAPH_NODE_CMD: 'nonexistent-cmd',
@@ -18,4 +18,35 @@ it('exits when graph-node fails to spawn', function () {
   expect(res.status).to.equal(1);
   expect(res.stderr).to.include('Failed to spawn graph-node');
   expect(contents).to.match(/Spawn error/);
+});
+
+it('shuts down on SIGTERM', function (done) {
+  const logFile = 'subgraph-server.signal.log';
+  const child = spawn(
+    'node',
+    ['-r', 'ts-node/register/transpile-only', 'scripts/subgraph-server.ts'],
+    {
+      env: {
+        ...process.env,
+        GRAPH_NODE_CMD: 'node',
+        GRAPH_NODE_ARGS: "-e setTimeout(() => {}, 10000)",
+        LOG_FILE: logFile,
+      },
+      stdio: 'ignore',
+    },
+  );
+
+  child.on('exit', (code) => {
+    fs.unlinkSync(logFile);
+    try {
+      expect(code).to.equal(0);
+      done();
+    } catch (err) {
+      done(err as Error);
+    }
+  });
+
+  setTimeout(() => {
+    child.kill('SIGTERM');
+  }, 500);
 });

--- a/scripts/subgraph-server.ts
+++ b/scripts/subgraph-server.ts
@@ -141,3 +141,13 @@ process.on('unhandledRejection', (err) => {
 
 start();
 setInterval(check, healthInterval);
+
+function shutdown() {
+  try {
+    child?.kill();
+  } catch {}
+  process.exit(0);
+}
+
+process.once('SIGINT', shutdown);
+process.once('SIGTERM', shutdown);


### PR DESCRIPTION
## Summary
- shut down `graph-node` when the server receives SIGINT/SIGTERM
- test the new signal handling
- mention clean shutdown in user docs

## Testing
- `npx mocha -r ts-node/register/transpile-only scripts/subgraph-server.test.ts` *(fails: ENOENT errors)*

------
https://chatgpt.com/codex/tasks/task_e_6869aa683b5083338e9e3934c1e16d64