### PR TITLE
Document CLI commands

### DIFF
--- a/docs/Todo-fuer-User.md
+++ b/docs/Todo-fuer-User.md
@@ -7,3 +7,28 @@ npm run devstack
 ```
 
 Beende alle Prozesse gemeinsam mit `Ctrl+C`.
+
+## CLI-Befehle
+
+`scripts/cli.ts` fasst verschiedene Hardhat-Tasks zusammen. Starte das CLI mit
+
+```bash
+node scripts/cli.ts <befehl> [Optionen]
+```
+
+Beispiele für die neuen Kommandos:
+
+```bash
+# Vertrag pausieren
+node scripts/cli.ts pause --network hardhat
+
+# Vertrag wieder aktivieren
+node scripts/cli.ts unpause --network hardhat
+
+# Plan deaktivieren
+node scripts/cli.ts disable --plan-id 0 --network hardhat
+
+# Merchant für einen Plan ändern
+node scripts/cli.ts update-merchant --plan-id 0 \
+  --merchant 0xDEADBEEF... --network hardhat
+```


### PR DESCRIPTION
## Summary
- document CLI usage for pause/unpause/disable/update-merchant

## Testing
- `npx prettier --check docs/Todo-fuer-User.md`
- `npm run lint` *(fails: Parsing error "parserOptions.project" ...)*

------
https://chatgpt.com/codex/tasks/task_e_6869aa69db908333903ba0fc6872518b