### PR TITLE
Add revenue analytics charts

### DIFF
--- a/e2e/analytics.spec.ts
+++ b/e2e/analytics.spec.ts
@@ -1,0 +1,78 @@
+import { test, expect } from '@playwright/test';
+import { spawn } from 'child_process';
+import * as path from 'path';
+import http from 'http';
+
+const SUBGRAPH_URL =
+  'http://localhost:8000/subgraphs/name/subscription-subgraph/graphql';
+
+let frontend: any;
+let server: http.Server;
+
+const data = {
+  plans: [
+    { id: '0', totalPaid: '100' },
+    { id: '1', totalPaid: '50' },
+  ],
+  payments: [{ planId: '0', amount: '10' }],
+};
+
+function startGraphServer() {
+  server = http.createServer((req, res) => {
+    if (req.method !== 'POST') {
+      res.statusCode = 404;
+      return res.end();
+    }
+    let body = '';
+    req.on('data', (chunk) => (body += chunk));
+    req.on('end', () => {
+      const { query } = JSON.parse(body || '{}');
+      if (query && query.includes('plans')) {
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ data: { plans: data.plans } }));
+      } else if (query && query.includes('payments')) {
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ data: { payments: data.payments } }));
+      } else {
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ data: {} }));
+      }
+    });
+  });
+  server.listen(8000);
+}
+
+function stopGraphServer() {
+  if (server) server.close();
+}
+
+test.beforeAll(async () => {
+  startGraphServer();
+  frontend = spawn('npm', ['run', 'dev', '--', '-p', '3000'], {
+    cwd: path.join(__dirname, '..', 'frontend'),
+    env: {
+      ...process.env,
+      NEXT_PUBLIC_CONTRACT_ADDRESS:
+        '0x0000000000000000000000000000000000000000',
+      NEXT_PUBLIC_CHAIN_ID: '31337',
+      NEXT_PUBLIC_RPC_URL: 'http://127.0.0.1:8545',
+      NEXT_PUBLIC_SUBGRAPH_URL: SUBGRAPH_URL,
+    },
+    stdio: 'inherit',
+  });
+  await new Promise((res) => setTimeout(res, 10000));
+});
+
+test.afterAll(() => {
+  if (frontend) frontend.kill();
+  stopGraphServer();
+});
+
+test('shows revenue chart', async ({ page }) => {
+  await page.goto('/analytics');
+  await expect(page.getByRole('heading', { name: 'Analytics' })).toBeVisible();
+  await expect(page.locator('canvas').first()).toBeVisible();
+  await page.fill('#filter-plan', '0');
+  await page.click('text=Apply');
+  await expect(page.locator('canvas').nth(1)).toBeVisible();
+});

--- a/frontend/generated/graphql.ts
+++ b/frontend/generated/graphql.ts
@@ -1,0 +1,119 @@
+import { TypedDocumentNode as DocumentNode } from '@graphql-typed-document-node/core';
+export type Maybe<T> = T | null;
+export type InputMaybe<T> = Maybe<T>;
+export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> };
+export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Maybe<T[SubKey]> };
+export type MakeEmpty<T extends { [key: string]: unknown }, K extends keyof T> = { [_ in K]?: never };
+export type Incremental<T> = T | { [P in keyof T]?: P extends ' $fragmentName' | '__typename' ? T[P] : never };
+/** All built-in and custom scalars, mapped to their actual values */
+export type Scalars = {
+  ID: { input: string; output: string; }
+  String: { input: string; output: string; }
+  Boolean: { input: boolean; output: boolean; }
+  Int: { input: number; output: number; }
+  Float: { input: number; output: number; }
+  BigInt: { input: any; output: any; }
+  Bytes: { input: any; output: any; }
+};
+
+export enum OrderDirection {
+  Asc = 'asc',
+  Desc = 'desc'
+}
+
+export type Payment = {
+  __typename?: 'Payment';
+  amount: Scalars['BigInt']['output'];
+  id: Scalars['ID']['output'];
+  newNextPaymentDate: Scalars['BigInt']['output'];
+  planId: Scalars['BigInt']['output'];
+  user: Scalars['Bytes']['output'];
+};
+
+export type PaymentWhereInput = {
+  newNextPaymentDate_gte?: InputMaybe<Scalars['BigInt']['input']>;
+  newNextPaymentDate_lte?: InputMaybe<Scalars['BigInt']['input']>;
+  planId?: InputMaybe<Scalars['BigInt']['input']>;
+};
+
+export enum Payment_OrderBy {
+  Id = 'id'
+}
+
+export type Plan = {
+  __typename?: 'Plan';
+  active: Scalars['Boolean']['output'];
+  billingCycle: Scalars['BigInt']['output'];
+  id: Scalars['ID']['output'];
+  merchant: Scalars['Bytes']['output'];
+  price: Scalars['BigInt']['output'];
+  priceFeedAddress: Scalars['Bytes']['output'];
+  priceInUsd: Scalars['Boolean']['output'];
+  token: Scalars['Bytes']['output'];
+  tokenDecimals: Scalars['Int']['output'];
+  totalPaid: Scalars['BigInt']['output'];
+  usdPrice: Scalars['BigInt']['output'];
+};
+
+export type Query = {
+  __typename?: 'Query';
+  payments: Array<Payment>;
+  plans: Array<Plan>;
+  subscriptions: Array<Subscription>;
+};
+
+
+export type QueryPaymentsArgs = {
+  orderBy?: InputMaybe<Payment_OrderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<PaymentWhereInput>;
+};
+
+
+export type QuerySubscriptionsArgs = {
+  where?: InputMaybe<SubscriptionWhereInput>;
+};
+
+export type Subscription = {
+  __typename?: 'Subscription';
+  cancelled?: Maybe<Scalars['Boolean']['output']>;
+  id: Scalars['ID']['output'];
+  nextPaymentDate?: Maybe<Scalars['BigInt']['output']>;
+  planId: Scalars['BigInt']['output'];
+  user: Scalars['Bytes']['output'];
+};
+
+export type SubscriptionWhereInput = {
+  cancelled?: InputMaybe<Scalars['Boolean']['input']>;
+};
+
+export type ActiveSubscriptionsQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type ActiveSubscriptionsQuery = { __typename?: 'Query', subscriptions: Array<{ __typename?: 'Subscription', id: string, user: any, planId: any, nextPaymentDate?: any | null }> };
+
+export type PaymentsQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type PaymentsQuery = { __typename?: 'Query', payments: Array<{ __typename?: 'Payment', id: string, user: any, planId: any, amount: any, newNextPaymentDate: any }> };
+
+export type PlansQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type PlansQuery = { __typename?: 'Query', plans: Array<{ __typename?: 'Plan', id: string, totalPaid: any }> };
+
+export type RevenueQueryVariables = Exact<{
+  planId?: InputMaybe<Scalars['BigInt']['input']>;
+  from?: InputMaybe<Scalars['BigInt']['input']>;
+  to?: InputMaybe<Scalars['BigInt']['input']>;
+}>;
+
+
+export type RevenueQuery = { __typename?: 'Query', payments: Array<{ __typename?: 'Payment', planId: any, amount: any }> };
+
+
+export const ActiveSubscriptionsDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"ActiveSubscriptions"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"subscriptions"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"where"},"value":{"kind":"ObjectValue","fields":[{"kind":"ObjectField","name":{"kind":"Name","value":"cancelled"},"value":{"kind":"BooleanValue","value":false}}]}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"user"}},{"kind":"Field","name":{"kind":"Name","value":"planId"}},{"kind":"Field","name":{"kind":"Name","value":"nextPaymentDate"}}]}}]}}]} as unknown as DocumentNode<ActiveSubscriptionsQuery, ActiveSubscriptionsQueryVariables>;
+export const PaymentsDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"Payments"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"payments"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"orderBy"},"value":{"kind":"EnumValue","value":"id"}},{"kind":"Argument","name":{"kind":"Name","value":"orderDirection"},"value":{"kind":"EnumValue","value":"desc"}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"user"}},{"kind":"Field","name":{"kind":"Name","value":"planId"}},{"kind":"Field","name":{"kind":"Name","value":"amount"}},{"kind":"Field","name":{"kind":"Name","value":"newNextPaymentDate"}}]}}]}}]} as unknown as DocumentNode<PaymentsQuery, PaymentsQueryVariables>;
+export const PlansDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"Plans"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"plans"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"totalPaid"}}]}}]}}]} as unknown as DocumentNode<PlansQuery, PlansQueryVariables>;
+export const RevenueDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"Revenue"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"planId"}},"type":{"kind":"NamedType","name":{"kind":"Name","value":"BigInt"}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"from"}},"type":{"kind":"NamedType","name":{"kind":"Name","value":"BigInt"}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"to"}},"type":{"kind":"NamedType","name":{"kind":"Name","value":"BigInt"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"payments"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"where"},"value":{"kind":"ObjectValue","fields":[{"kind":"ObjectField","name":{"kind":"Name","value":"planId"},"value":{"kind":"Variable","name":{"kind":"Name","value":"planId"}}},{"kind":"ObjectField","name":{"kind":"Name","value":"newNextPaymentDate_gte"},"value":{"kind":"Variable","name":{"kind":"Name","value":"from"}}},{"kind":"ObjectField","name":{"kind":"Name","value":"newNextPaymentDate_lte"},"value":{"kind":"Variable","name":{"kind":"Name","value":"to"}}}]}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"planId"}},{"kind":"Field","name":{"kind":"Name","value":"amount"}}]}}]}}]} as unknown as DocumentNode<RevenueQuery, RevenueQueryVariables>;

--- a/frontend/lib/subgraph.ts
+++ b/frontend/lib/subgraph.ts
@@ -4,6 +4,7 @@ import {
   ActiveSubscriptionsDocument,
   PaymentsDocument,
   PlansDocument,
+  RevenueDocument,
 } from '../generated/graphql';
 
 const client = new ApolloClient({
@@ -43,6 +44,21 @@ export const PLANS_QUERY = gql`
   }
 `;
 
+export const REVENUE_QUERY = gql`
+  query Revenue($planId: BigInt, $from: BigInt, $to: BigInt) {
+    payments(
+      where: {
+        planId: $planId
+        newNextPaymentDate_gte: $from
+        newNextPaymentDate_lte: $to
+      }
+    ) {
+      planId
+      amount
+    }
+  }
+`;
+
 export async function getActiveSubscriptions() {
   const { data } = await client.query({ query: ActiveSubscriptionsDocument });
   return data.subscriptions;
@@ -58,10 +74,19 @@ export async function getPlans() {
   return data.plans;
 }
 
+export async function getRevenue(planId?: string, from?: number, to?: number) {
+  const { data } = await client.query({
+    query: RevenueDocument,
+    variables: { planId, from, to },
+  });
+  return data.payments;
+}
+
 export default client;
 
 export {
   ActiveSubscriptionsDocument,
   PaymentsDocument,
   PlansDocument,
+  RevenueDocument,
 };

--- a/frontend/local-schema.graphql
+++ b/frontend/local-schema.graphql
@@ -14,6 +14,12 @@ input SubscriptionWhereInput {
   cancelled: Boolean
 }
 
+input PaymentWhereInput {
+  planId: BigInt
+  newNextPaymentDate_gte: BigInt
+  newNextPaymentDate_lte: BigInt
+}
+
 type Plan {
   id: ID!
   totalPaid: BigInt!
@@ -37,6 +43,10 @@ type Payment {
 
 type Query {
   subscriptions(where: SubscriptionWhereInput): [Subscription!]!
-  payments(orderBy: Payment_OrderBy, orderDirection: OrderDirection): [Payment!]!
+  payments(
+    where: PaymentWhereInput
+    orderBy: Payment_OrderBy
+    orderDirection: OrderDirection
+  ): [Payment!]!
   plans: [Plan!]!
 }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,11 +11,13 @@
         "@apollo/client": "^3.13.8",
         "@coinbase/wallet-sdk": "^4.0.0",
         "@walletconnect/web3-provider": "^1.8.0",
+        "chart.js": "^4.5.0",
         "ethers": "^6.14.4",
         "graphql": "^16.11.0",
         "jest-environment-jsdom": "^29.7.0",
         "next": "15.3.4",
         "react": "^19.0.0",
+        "react-chartjs-2": "^5.3.0",
         "react-dom": "^19.0.0"
       },
       "devDependencies": {
@@ -2868,6 +2870,12 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@kurkle/color": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
+      "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
+      "license": "MIT"
     },
     "node_modules/@metamask/safe-event-emitter": {
       "version": "2.0.0",
@@ -5793,6 +5801,18 @@
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/chart.js": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.0.tgz",
+      "integrity": "sha512-aYeC/jDgSEx8SHWZvANYMioYMZ2KX02W6f6uVfyteuCGcadDLcYVHdfdygsTQkQ4TKn5lghoojAsPj5pu0SnvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@kurkle/color": "^0.3.0"
+      },
+      "engines": {
+        "pnpm": ">=8"
+      }
     },
     "node_modules/checkpoint-store": {
       "version": "1.1.0",
@@ -13317,6 +13337,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-chartjs-2": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/react-chartjs-2/-/react-chartjs-2-5.3.0.tgz",
+      "integrity": "sha512-UfZZFnDsERI3c3CZGxzvNJd02SHjaSJ8kgW1djn65H1KK8rehwTjyrRKOG3VTMG8wtHZ5rgAO5oTHtHi9GCCmw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "chart.js": "^4.1.1",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/react-dom": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,15 +15,21 @@
     "@apollo/client": "^3.13.8",
     "@coinbase/wallet-sdk": "^4.0.0",
     "@walletconnect/web3-provider": "^1.8.0",
+    "chart.js": "^4.5.0",
     "ethers": "^6.14.4",
     "graphql": "^16.11.0",
     "jest-environment-jsdom": "^29.7.0",
     "next": "15.3.4",
     "react": "^19.0.0",
+    "react-chartjs-2": "^5.3.0",
     "react-dom": "^19.0.0"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",
+    "@graphql-codegen/cli": "^5.0.7",
+    "@graphql-codegen/typed-document-node": "^5.1.2",
+    "@graphql-codegen/typescript": "^4.1.6",
+    "@graphql-codegen/typescript-operations": "^4.6.1",
     "@testing-library/jest-dom": "^6.1.0",
     "@testing-library/react": "^14.2.0",
     "@testing-library/user-event": "^14.6.1",
@@ -38,10 +44,6 @@
     "jest": "^29.7.0",
     "ts-jest": "^29.1.1",
     "typescript": "^5",
-    "zod": "^3.22.4",
-    "@graphql-codegen/cli": "^5.0.7",
-    "@graphql-codegen/typescript": "^4.1.6",
-    "@graphql-codegen/typescript-operations": "^4.6.1",
-    "@graphql-codegen/typed-document-node": "^5.1.2"
+    "zod": "^3.22.4"
   }
 }


### PR DESCRIPTION
## Summary
- add Chart.js dependencies
- fetch revenue information from the subgraph
- show plan revenue charts with filters on analytics page
- update local GraphQL schema and generated types
- test analytics revenue via new e2e test

## Testing
- `npm run lint` *(fails: 82 errors)*
- `npm run test:e2e` *(fails: address in use / missing artifacts)*

------
https://chatgpt.com/codex/tasks/task_e_6869b3bbb39c83339401c9aac8fef296