### PR TITLE
Add CLI guide and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,8 @@ The command sets `REPORT_GAS=true` and prints a table similar to:
 Additional documentation can be found in the [docs](docs/) directory.
 For a step-by-step production deployment guide see
 [docs/production-guide.md](docs/production-guide.md).
+For a reference of CLI commands see
+[docs/cli-guide.md](docs/cli-guide.md).
 
 ## Creating a Plan
 

--- a/docs/cli-guide.md
+++ b/docs/cli-guide.md
@@ -1,0 +1,55 @@
+# CLI Guide
+
+This guide shows common ways to invoke `scripts/cli.ts` using `ts-node`.
+All commands support the `--network` flag to select a Hardhat network.
+
+## List existing plans
+
+```bash
+npx ts-node scripts/cli.ts list --subscription <address> --network hardhat
+```
+
+## Create a new plan
+
+```bash
+npx ts-node scripts/cli.ts create \
+  --subscription <address> \
+  --merchant <merchant> \
+  --token <erc20> \
+  --price 1000 \
+  --billing-cycle 3600 \
+  --network hardhat
+```
+
+## Update a plan
+
+```bash
+npx ts-node scripts/cli.ts update \
+  --subscription <address> \
+  --plan-id 0 \
+  --price 2000 \
+  --network hardhat
+```
+
+## Pause and unpause
+
+```bash
+npx ts-node scripts/cli.ts pause --subscription <address> --network hardhat
+npx ts-node scripts/cli.ts unpause --subscription <address> --network hardhat
+```
+
+## Disable a plan
+
+```bash
+npx ts-node scripts/cli.ts disable --subscription <address> --plan-id 0 --network hardhat
+```
+
+## Update the merchant
+
+```bash
+npx ts-node scripts/cli.ts update-merchant \
+  --subscription <address> \
+  --plan-id 0 \
+  --merchant <newMerchant> \
+  --network hardhat
+```

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "coverage-check": "node scripts/check-coverage.js",
     "slither": "slither .",
     "test-subgraph": "graph test",
+    "test:cli": "mocha -r ts-node/register/transpile-only scripts/cli.test.ts",
     "test:e2e": "playwright test",
     "devstack": "node scripts/start-dev.ts"
   },

--- a/scripts/cli.test.ts
+++ b/scripts/cli.test.ts
@@ -1,0 +1,33 @@
+import { expect } from 'chai';
+import { spawnSync } from 'child_process';
+
+function run(args: string[]) {
+  return spawnSync(
+    'node',
+    ['-r', 'ts-node/register/transpile-only', 'scripts/cli.ts', ...args],
+    { encoding: 'utf8' }
+  );
+}
+
+describe('cli.ts', function () {
+  it('shows global help', function () {
+    const res = run(['--help']);
+    expect(res.stdout).to.contain('Manage subscription plans');
+  });
+
+  it('shows help for subcommands', function () {
+    expect(run(['list', '--help']).stdout).to.contain('List existing plans');
+    expect(run(['create', '--help']).stdout).to.contain('Create a new plan');
+    expect(run(['update', '--help']).stdout).to.contain('Update an existing plan');
+    expect(run(['pause', '--help']).stdout).to.contain('Pause the subscription contract');
+    expect(run(['unpause', '--help']).stdout).to.contain('Unpause the subscription contract');
+    expect(run(['disable', '--help']).stdout).to.contain('Disable a subscription plan');
+    expect(run(['update-merchant', '--help']).stdout).to.contain('Update the merchant of a plan');
+  });
+
+  it('fails when subscription is missing', function () {
+    const res = run(['list']);
+    expect(res.status).to.not.equal(0);
+    expect(res.stderr).to.match(/subscription address missing/i);
+  });
+});


### PR DESCRIPTION
## Summary
- document CLI usage
- test CLI help output with mocha
- add test:cli npm script
- reference the new guide in README

## Testing
- `npm run test:cli` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869b3bbb82483338e136b63c4166331