### PR TITLE
Add totalPayments tracking in subgraph

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,6 +304,13 @@ npx hardhat run scripts/upgrade.ts --network <network>
 ## Subgraph
 
 The `subgraph/` directory contains a minimal [The Graph](https://thegraph.com) setup for indexing events emitted by `Subscription.sol`.
+After changing `schema.graphql` or files in `subgraph/src/`, run
+
+```bash
+npm run build-subgraph
+```
+
+to regenerate the manifest and type definitions used by tests.
 Provide the network name and the deployed contract address via the `NETWORK` and
 `CONTRACT_ADDRESS` variables (or `--network` and `--address` arguments) before
 building. These variables are also used by `npm run prepare-subgraph`:

--- a/subgraph/schema.graphql
+++ b/subgraph/schema.graphql
@@ -16,6 +16,7 @@ type Subscription @entity(immutable: false) {
   id: ID!
   user: Bytes!
   planId: BigInt!
+  totalPayments: BigInt!
   nextPaymentDate: BigInt
   cancelled: Boolean
 }

--- a/subgraph/src/mapping.ts
+++ b/subgraph/src/mapping.ts
@@ -57,6 +57,7 @@ export function handleSubscribed(event: Subscribed): void {
     sub = new Subscription(id)
     sub.user = event.params.user
     sub.planId = event.params.planId
+    sub.totalPayments = BigInt.zero()
   }
   sub.nextPaymentDate = event.params.nextPaymentDate
   sub.cancelled = false
@@ -82,6 +83,7 @@ export function handlePaymentProcessed(event: PaymentProcessed): void {
   let sub = Subscription.load(subId)
   if (sub) {
     sub.nextPaymentDate = event.params.newNextPaymentDate
+    sub.totalPayments = (sub.totalPayments || BigInt.zero()).plus(BigInt.fromI32(1))
     sub.save()
   }
 }

--- a/subgraph/tests/integration.test.ts
+++ b/subgraph/tests/integration.test.ts
@@ -243,12 +243,13 @@ describe('Subgraph integration', function () {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           query:
-            '{ plans { id totalPaid merchant } subscriptions { id } payments { id planId amount } }',
+            '{ plans { id totalPaid merchant } subscriptions { id totalPayments } payments { id planId amount } }',
         }),
       },
     );
     const json = await res.json();
     expect(json.data.subscriptions.length).to.equal(1);
+    expect(json.data.subscriptions[0].totalPayments).to.equal('1');
     expect(json.data.payments.length).to.equal(1);
     expect(json.data.plans[0].totalPaid).to.equal(
       ethers.parseUnits('1', 18).toString(),

--- a/subgraph/tests/mapping.test.ts
+++ b/subgraph/tests/mapping.test.ts
@@ -156,6 +156,7 @@ test("handleSubscribed creates subscription", () => {
   handleSubscribed(sub)
   assert.entityCount("Subscription", 1)
   assert.fieldEquals("Subscription", "0x0000000000000000000000000000000000000005-2", "nextPaymentDate", "1000")
+  assert.fieldEquals("Subscription", "0x0000000000000000000000000000000000000005-2", "totalPayments", "0")
   clearStore()
 })
 
@@ -169,6 +170,7 @@ test("handlePaymentProcessed stores payment and updates subscription", () => {
   assert.entityCount("Payment", 1)
   assert.fieldEquals("Payment", "0xa16081f360e3847006db660bae1c6d1b2e17ec2a-0", "amount", "50")
   assert.fieldEquals("Subscription", "0x0000000000000000000000000000000000000005-2", "nextPaymentDate", "2000")
+  assert.fieldEquals("Subscription", "0x0000000000000000000000000000000000000005-2", "totalPayments", "1")
   clearStore()
 })
 


### PR DESCRIPTION
## Summary
- extend `Subscription` entity with `totalPayments`
- track `totalPayments` in the mapping logic
- adjust subgraph unit/integration tests
- document how to rebuild the subgraph

## Testing
- `npm test` *(fails: price overflow etc.)*
- `npm run test-subgraph` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_6869b3bdd4148333a96faee4b0b6079e