### PR TITLE
Add NetworkStatus component

### DIFF
--- a/frontend/__tests__/NetworkStatus.test.tsx
+++ b/frontend/__tests__/NetworkStatus.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen } from '@testing-library/react';
+import NetworkStatus from '../lib/NetworkStatus';
+import { StoreProvider } from '../lib/store';
+import MessageBar from '../lib/MessageBar';
+
+const mockGetNetwork = jest.fn();
+const mockGetBlockNumber = jest.fn();
+
+jest.mock('ethers', () => ({
+  ethers: {
+    BrowserProvider: jest.fn(() => ({
+      getNetwork: mockGetNetwork,
+      getBlockNumber: mockGetBlockNumber,
+    })),
+    JsonRpcProvider: jest.fn(() => ({
+      getNetwork: mockGetNetwork,
+      getBlockNumber: mockGetBlockNumber,
+    })),
+  },
+}));
+
+function Wrapper() {
+  return (
+    <StoreProvider>
+      <MessageBar />
+      <NetworkStatus />
+    </StoreProvider>
+  );
+}
+
+test('displays network name and block number', async () => {
+  mockGetNetwork.mockResolvedValue({ name: 'testnet', chainId: 1 });
+  mockGetBlockNumber.mockResolvedValue(123);
+  render(<Wrapper />);
+  expect(await screen.findByText('testnet #123')).toBeInTheDocument();
+});
+
+test('shows error message when provider fails', async () => {
+  mockGetNetwork.mockRejectedValue(new Error('fail'));
+  render(<Wrapper />);
+  expect(await screen.findByText('fail')).toBeInTheDocument();
+});

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -3,6 +3,7 @@ import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import { StoreProvider } from "../lib/store";
 import MessageBar from "../lib/MessageBar";
+import NetworkStatus from "../lib/NetworkStatus";
 import { PlansProvider } from "../lib/plansStore";
 import I18nProvider from "../lib/I18nProvider";
 import LanguageSwitcher from "../lib/LanguageSwitcher";
@@ -34,6 +35,7 @@ export default function RootLayout({
           <StoreProvider>
             <PlansProvider>
               <LanguageSwitcher />
+              <NetworkStatus />
               <MessageBar />
               {children}
             </PlansProvider>

--- a/frontend/lib/NetworkStatus.tsx
+++ b/frontend/lib/NetworkStatus.tsx
@@ -1,0 +1,50 @@
+'use client';
+import { useEffect, useState } from 'react';
+import { ethers } from 'ethers';
+import { env } from './env';
+import { useStore } from './store';
+
+export default function NetworkStatus() {
+  const [name, setName] = useState('');
+  const [block, setBlock] = useState<number | null>(null);
+  const { setMessage } = useStore();
+
+  useEffect(() => {
+    let cancelled = false;
+    const provider: ethers.Provider =
+      typeof window !== 'undefined' && (window as any).ethereum
+        ? new ethers.BrowserProvider((window as any).ethereum)
+        : new ethers.JsonRpcProvider(env.NEXT_PUBLIC_RPC_URL);
+
+    async function load() {
+      try {
+        const net = await provider.getNetwork();
+        const blk = await provider.getBlockNumber();
+        if (!cancelled) {
+          setName(net.name === 'unknown' ? String(net.chainId) : net.name);
+          setBlock(blk);
+        }
+      } catch (err) {
+        if (!cancelled) {
+          const msg = err instanceof Error ? err.message : 'Failed to connect';
+          setMessage({ text: msg, type: 'error' });
+        }
+      }
+    }
+
+    load();
+    const id = setInterval(load, 10000);
+    return () => {
+      cancelled = true;
+      clearInterval(id);
+    };
+  }, [setMessage]);
+
+  if (!name || block === null) return null;
+
+  return (
+    <span className="network-status" style={{ float: 'right', marginLeft: 10 }}>
+      {name} #{block}
+    </span>
+  );
+}


### PR DESCRIPTION
## Summary
- poll provider for chain name & block number
- show network status in layout
- report connection errors via MessageBar
- add unit tests for new component

## Testing
- `npm test --prefix frontend` *(fails: 7 failed, 7 passed)*

------
https://chatgpt.com/codex/tasks/task_e_686a53103e24833398bdca3a7f208c1f