### PR TITLE
Add status command to CLI

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -9,6 +9,7 @@ import './tasks/update-plan';
 import './tasks/pause';
 import './tasks/disable-plan';
 import './tasks/update-merchant';
+import './tasks/status';
 
 import path from 'path';
 import * as dotenv from 'dotenv';

--- a/scripts/cli.test.ts
+++ b/scripts/cli.test.ts
@@ -10,6 +10,7 @@ function run(args: string[]) {
 }
 
 describe('cli.ts', function () {
+  this.timeout(20000);
   it('shows global help', function () {
     const res = run(['--help']);
     expect(res.stdout).to.contain('Manage subscription plans');
@@ -23,6 +24,11 @@ describe('cli.ts', function () {
     expect(run(['unpause', '--help']).stdout).to.contain('Unpause the subscription contract');
     expect(run(['disable', '--help']).stdout).to.contain('Disable a subscription plan');
     expect(run(['update-merchant', '--help']).stdout).to.contain('Update the merchant of a plan');
+  });
+
+  it('shows help for status command', function () {
+    const res = run(['status', '--help']);
+    expect(res.stdout).to.contain('Show subscription contract status');
   });
 
   it('fails when subscription is missing', function () {

--- a/scripts/cli.ts
+++ b/scripts/cli.ts
@@ -78,6 +78,11 @@ async function disablePlan(opts: any) {
   await run('disable-plan', opts);
 }
 
+async function showStatus(opts: any) {
+  const { run } = await loadHardhat();
+  await run('status', opts);
+}
+
 async function updateMerchant(opts: any) {
   const { run } = await loadHardhat();
   await run('update-merchant', opts);
@@ -141,6 +146,12 @@ program
   .action((opts) => unpauseContract(opts));
 
 program
+  .command('status')
+  .description('Show subscription contract status')
+  .option('-s, --subscription <address>', 'Subscription contract address')
+  .action((opts) => showStatus(opts));
+
+program
   .command('disable')
   .description('Disable a subscription plan')
   .option('-s, --subscription <address>', 'Subscription contract address')
@@ -155,7 +166,10 @@ program
   .option('-m, --merchant <address>', 'New merchant address')
   .action((opts) => updateMerchant(opts));
 
-program.parseAsync().catch((err) => {
+const parsePromise = (program as any).parseAsync
+  ? (program as any).parseAsync(process.argv)
+  : Promise.resolve(program.parse(process.argv));
+parsePromise.catch((err: any) => {
   console.error(err);
   process.exitCode = 1;
 });

--- a/tasks/status.ts
+++ b/tasks/status.ts
@@ -1,0 +1,35 @@
+import { task } from 'hardhat/config';
+import { HardhatRuntimeEnvironment } from 'hardhat/types';
+
+/**
+ * Prints status information about the subscription contract.
+ *
+ * Example:
+ * npx hardhat status --network hardhat --subscription 0xSUB
+ */
+
+task('status', 'Show subscription contract status')
+  .addOptionalParam('subscription', 'Subscription contract address')
+  .setAction(async (args: any, hre: HardhatRuntimeEnvironment) => {
+    const subscription = args.subscription ?? process.env.SUBSCRIPTION_ADDRESS;
+    if (!subscription) throw new Error('subscription address missing');
+    const [signer] = await hre.ethers.getSigners();
+    const contract = await hre.ethers.getContractAt('SubscriptionUpgradeable', subscription, signer);
+    const paused = await contract.paused();
+    const nextId: bigint = await contract.nextPlanId();
+    const active: string[] = [];
+    const inactive: string[] = [];
+    for (let i = 0n; i < nextId; i++) {
+      const plan = await contract.plans(i);
+      (plan.active ? active : inactive).push(i.toString());
+    }
+    const info = {
+      paused,
+      nextPlanId: nextId.toString(),
+      activePlans: active,
+      inactivePlans: inactive,
+    };
+    console.log(JSON.stringify(info, null, 2));
+  });
+
+export {};


### PR DESCRIPTION
## Summary
- add `status` task for Hardhat
- expose new CLI subcommand and load it in `hardhat.config.ts`
- make CLI compatible with commander v2
- extend CLI tests with coverage for the new subcommand

## Testing
- `npm run test:cli`
- `npm test` *(fails: price overflow and other contract tests)*

------
https://chatgpt.com/codex/tasks/task_e_686a530e02908333a1986df68ddae3ee