### PR TITLE
Add subscription management CLI commands

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -10,6 +10,9 @@ import './tasks/pause';
 import './tasks/disable-plan';
 import './tasks/update-merchant';
 import './tasks/status';
+import './tasks/subscribe';
+import './tasks/cancel';
+import './tasks/process-payment';
 
 import path from 'path';
 import * as dotenv from 'dotenv';

--- a/scripts/cli.test.ts
+++ b/scripts/cli.test.ts
@@ -24,6 +24,9 @@ describe('cli.ts', function () {
     expect(run(['unpause', '--help']).stdout).to.contain('Unpause the subscription contract');
     expect(run(['disable', '--help']).stdout).to.contain('Disable a subscription plan');
     expect(run(['update-merchant', '--help']).stdout).to.contain('Update the merchant of a plan');
+    expect(run(['subscribe', '--help']).stdout).to.contain('Subscribe to a plan');
+    expect(run(['cancel', '--help']).stdout).to.contain('Cancel an active subscription');
+    expect(run(['process-payment', '--help']).stdout).to.contain('Process a subscription payment');
   });
 
   it('shows help for status command', function () {
@@ -35,5 +38,21 @@ describe('cli.ts', function () {
     const res = run(['list']);
     expect(res.status).to.not.equal(0);
     expect(res.stderr).to.match(/subscription address missing/i);
+
+    const resSub = run(['subscribe']);
+    expect(resSub.status).to.not.equal(0);
+    expect(resSub.stderr).to.match(/subscription address missing/i);
+
+    const resCancel = run(['cancel']);
+    expect(resCancel.status).to.not.equal(0);
+    expect(resCancel.stderr).to.match(/subscription address missing/i);
+
+    const resPay = run(['process-payment']);
+    expect(resPay.status).to.not.equal(0);
+    expect(resPay.stderr).to.match(/subscription address missing/i);
+
+    const resPayUser = run(['process-payment', '--subscription', '0x0000000000000000000000000000000000000000']);
+    expect(resPayUser.status).to.not.equal(0);
+    expect(resPayUser.stderr).to.match(/user address missing/i);
   });
 });

--- a/scripts/cli.ts
+++ b/scripts/cli.ts
@@ -88,6 +88,21 @@ async function updateMerchant(opts: any) {
   await run('update-merchant', opts);
 }
 
+async function subscribePlan(opts: any) {
+  const { run } = await loadHardhat();
+  await run('subscribe', opts);
+}
+
+async function cancelSubscription(opts: any) {
+  const { run } = await loadHardhat();
+  await run('cancel', opts);
+}
+
+async function processPayment(opts: any) {
+  const { run } = await loadHardhat();
+  await run('process-payment', opts);
+}
+
 const program = new Command();
 program
   .name('supscript-cli')
@@ -157,6 +172,28 @@ program
   .option('-s, --subscription <address>', 'Subscription contract address')
   .option('-i, --plan-id <id>', 'Plan ID')
   .action((opts) => disablePlan(opts));
+
+program
+  .command('subscribe')
+  .description('Subscribe to a plan')
+  .option('-s, --subscription <address>', 'Subscription contract address')
+  .option('-i, --plan-id <id>', 'Plan ID')
+  .action((opts) => subscribePlan(opts));
+
+program
+  .command('cancel')
+  .description('Cancel an active subscription')
+  .option('-s, --subscription <address>', 'Subscription contract address')
+  .option('-i, --plan-id <id>', 'Plan ID')
+  .action((opts) => cancelSubscription(opts));
+
+program
+  .command('process-payment')
+  .description('Process a subscription payment')
+  .option('-s, --subscription <address>', 'Subscription contract address')
+  .option('-u, --user <address>', 'Subscriber address')
+  .option('-i, --plan-id <id>', 'Plan ID')
+  .action((opts) => processPayment(opts));
 
 program
   .command('update-merchant')

--- a/tasks/cancel.ts
+++ b/tasks/cancel.ts
@@ -1,0 +1,29 @@
+import { task, types } from 'hardhat/config';
+import { HardhatRuntimeEnvironment } from 'hardhat/types';
+
+/**
+ * Cancels an active subscription.
+ *
+ * Example:
+ * npx hardhat cancel --network hardhat --subscription 0xSUB --plan-id 0
+ */
+
+task('cancel', 'Cancel an active subscription')
+  .addOptionalParam('subscription', 'Subscription contract address')
+  .addOptionalParam('planId', 'Plan ID', undefined, types.string)
+  .setAction(async (args: any, hre: HardhatRuntimeEnvironment) => {
+    const subscription = args.subscription ?? process.env.SUBSCRIPTION_ADDRESS;
+    if (!subscription) throw new Error('subscription address missing');
+    const planId = BigInt(args.planId ?? process.env.PLAN_ID ?? '0');
+    const [signer] = await hre.ethers.getSigners();
+    const contract = await hre.ethers.getContractAt(
+      'SubscriptionUpgradeable',
+      subscription,
+      signer,
+    );
+    const tx = await contract.cancelSubscription(planId);
+    await tx.wait();
+    console.log(`Subscription ${planId} cancelled with tx ${tx.hash}`);
+  });
+
+export {};

--- a/tasks/process-payment.ts
+++ b/tasks/process-payment.ts
@@ -1,0 +1,35 @@
+import { task, types } from 'hardhat/config';
+import { HardhatRuntimeEnvironment } from 'hardhat/types';
+
+/**
+ * Processes a subscription payment for the given user and plan.
+ *
+ * Example:
+ * npx hardhat process-payment --network hardhat \
+ *   --subscription 0xSUB --user 0xUSER --plan-id 0
+ */
+
+task('process-payment', 'Process a subscription payment')
+  .addOptionalParam('subscription', 'Subscription contract address')
+  .addOptionalParam('user', 'Subscriber address')
+  .addOptionalParam('planId', 'Plan ID', undefined, types.string)
+  .setAction(async (args: any, hre: HardhatRuntimeEnvironment) => {
+    const subscription = args.subscription ?? process.env.SUBSCRIPTION_ADDRESS;
+    if (!subscription) throw new Error('subscription address missing');
+    const user = args.user;
+    if (!user) throw new Error('user address missing');
+    const planId = BigInt(args.planId ?? process.env.PLAN_ID ?? '0');
+    const [signer] = await hre.ethers.getSigners();
+    const contract = await hre.ethers.getContractAt(
+      'SubscriptionUpgradeable',
+      subscription,
+      signer,
+    );
+    const tx = await contract.processPayment(user, planId);
+    await tx.wait();
+    console.log(
+      `Processed payment for ${user} plan ${planId} with tx ${tx.hash}`,
+    );
+  });
+
+export {};

--- a/tasks/subscribe.ts
+++ b/tasks/subscribe.ts
@@ -1,0 +1,29 @@
+import { task, types } from 'hardhat/config';
+import { HardhatRuntimeEnvironment } from 'hardhat/types';
+
+/**
+ * Subscribes the signer to a subscription plan.
+ *
+ * Example:
+ * npx hardhat subscribe --network hardhat --subscription 0xSUB --plan-id 0
+ */
+
+task('subscribe', 'Subscribe to a plan')
+  .addOptionalParam('subscription', 'Subscription contract address')
+  .addOptionalParam('planId', 'Plan ID', undefined, types.string)
+  .setAction(async (args: any, hre: HardhatRuntimeEnvironment) => {
+    const subscription = args.subscription ?? process.env.SUBSCRIPTION_ADDRESS;
+    if (!subscription) throw new Error('subscription address missing');
+    const planId = BigInt(args.planId ?? process.env.PLAN_ID ?? '0');
+    const [signer] = await hre.ethers.getSigners();
+    const contract = await hre.ethers.getContractAt(
+      'SubscriptionUpgradeable',
+      subscription,
+      signer,
+    );
+    const tx = await contract.subscribe(planId);
+    await tx.wait();
+    console.log(`Subscribed to plan ${planId} with tx ${tx.hash}`);
+  });
+
+export {};


### PR DESCRIPTION
## Summary
- implement Hardhat tasks for subscribing, cancelling and processing payments
- expose new commands in `scripts/cli.ts`
- test help output and missing parameter handling
- register tasks in `hardhat.config.ts`

## Testing
- `npm run lint` *(fails: prefer-const etc.)*
- `npm test` *(fails: 90 failing)*
- `npm run test:cli`

------
https://chatgpt.com/codex/tasks/task_e_686a672633e083338b60e0dfa46368be