### PR TITLE
Update deployment scripts

### DIFF
--- a/scripts/upgrade.ts
+++ b/scripts/upgrade.ts
@@ -1,5 +1,7 @@
-import { ethers, upgrades } from "hardhat";
-import { loadEnv } from "./env";
+import { ethers, upgrades, network } from 'hardhat';
+import { spawnSync } from 'child_process';
+import path from 'path';
+import { loadEnv } from './env';
 
 export async function upgrade() {
   const env = loadEnv();
@@ -23,6 +25,18 @@ export async function upgrade() {
     throw new Error(`Unexpected version: ${version}`);
   }
   console.log("Contract version:", version);
+
+  const net = process.env.NETWORK || process.env.HARDHAT_NETWORK || network.name;
+  const addr = proxy;
+  const childEnv = { ...process.env, NETWORK: net, CONTRACT_ADDRESS: addr };
+  const script = path.join(__dirname, 'prepare-subgraph.ts');
+  const res = spawnSync('node', ['-r', 'ts-node/register/transpile-only', script], {
+    stdio: 'inherit',
+    env: childEnv,
+  });
+  if (res.status !== 0) {
+    throw new Error('prepare-subgraph failed');
+  }
 }
 
 if (require.main === module) {

--- a/test/upgrade-script.ts
+++ b/test/upgrade-script.ts
@@ -59,4 +59,8 @@ MAINNET_PRIVATE_KEY=0x00
 
   const upgraded = await ethers.getContractAt('SubscriptionUpgradeableV2', await proxy.getAddress());
   expect(await upgraded.version()).to.equal('v2');
+
+  const manifest = path.resolve(__dirname, '..', 'subgraph', 'subgraph.local.yaml');
+  expect(fs.existsSync(manifest)).to.equal(true);
+  fs.unlinkSync(manifest);
 });


### PR DESCRIPTION
## Summary
- run `prepare-subgraph` when deploying or upgrading
- ensure generated subgraph manifest exists in upgrade test

## Testing
- `npx hardhat test test/upgrade-script.ts`
- `npm test` *(fails: 90 failing)*

------
https://chatgpt.com/codex/tasks/task_e_686a6726f4008333b3ab6feb4305a0a5