### PR TITLE
Format plan prices with decimals

### DIFF
--- a/frontend/__tests__/ManagePlans.test.tsx
+++ b/frontend/__tests__/ManagePlans.test.tsx
@@ -35,7 +35,7 @@ describe('ManagePlans page', () => {
     merchant: '0x',
     token: 'a',
     tokenDecimals: 18n,
-    price: 1n,
+    price: '0.000000000000000001',
     billingCycle: 1n,
     priceInUsd: false,
     usdPrice: 0n,

--- a/frontend/__tests__/PlansPage.test.tsx
+++ b/frontend/__tests__/PlansPage.test.tsx
@@ -24,7 +24,7 @@ describe('Plans page', () => {
           merchant: '0x',
           token: 'a',
           tokenDecimals: 18n,
-          price: 1n,
+          price: '0.000000000000000001',
           billingCycle: 1n,
           priceInUsd: false,
           usdPrice: 0n,
@@ -35,9 +35,15 @@ describe('Plans page', () => {
       reload: jest.fn(),
     });
     render(<Wrapper />);
-    const btn = screen.getByText(/Plan 0/);
+    const btn = screen.getByText(
+      'Plan 0: 0.000000000000000001 a alle 1s (active)',
+    );
     expect(btn).toBeInTheDocument();
     await userEvent.click(btn);
     expect(await screen.findByTestId('plan-details')).toBeInTheDocument();
+    expect(
+      screen.getByText('Price: 0.000000000000000001 a'),
+    ).toBeInTheDocument();
+    expect(screen.getByText('Billing: 1s')).toBeInTheDocument();
   });
 });

--- a/frontend/__tests__/plansStore.test.tsx
+++ b/frontend/__tests__/plansStore.test.tsx
@@ -1,12 +1,12 @@
 import { renderHook, act, waitFor } from '@testing-library/react';
-import { PlansProvider, usePlans, Plan } from '../lib/plansStore';
+import { PlansProvider, usePlans } from '../lib/plansStore';
 import { getContract } from '../lib/contract';
 
 jest.mock('../lib/contract', () => ({ getContract: jest.fn() }));
 
 const mockedGetContract = getContract as jest.Mock;
 
-function makePlan(token: string): Plan {
+function makePlan(token: string) {
   return {
     id: 0n,
     merchant: '0x',

--- a/frontend/app/plans/page.tsx
+++ b/frontend/app/plans/page.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react';
 import { usePlans } from '../../lib/plansStore';
 import useWallet from '../../lib/useWallet';
 import { useTranslation } from 'react-i18next';
+import Price from '../../lib/Price';
 
 export default function Plans() {
   const { account, connect } = useWallet();
@@ -61,7 +62,13 @@ export default function Plans() {
         {sorted.map((p) => (
           <li key={p.id.toString()}>
             <button onClick={() => setSelected(p.id)}>
-              {`Plan ${p.id.toString()}: token ${p.token} price ${p.price.toString()} billing ${p.billingCycle.toString()}s ${p.active ? t('plans.status_active') : t('plans.status_inactive')}`}
+              {`Plan ${p.id.toString()}: `}
+              <Price amount={p.price} decimals={p.tokenDecimals} symbol={p.token} />
+              {` alle ${
+                p.billingCycle % 86400n === 0n
+                  ? `${p.billingCycle / 86400n}\u202Fd`
+                  : `${p.billingCycle.toString()}s`
+              } ${p.active ? t('plans.status_active') : t('plans.status_inactive')}`}
             </button>
           </li>
         ))}
@@ -73,8 +80,16 @@ export default function Plans() {
             <li>{t('plans.detail_id')}: {detail.id.toString()}</li>
             <li>{t('plans.detail_merchant')}: {detail.merchant}</li>
             <li>{t('plans.detail_token')}: {detail.token}</li>
-            <li>{t('plans.detail_price')}: {detail.price.toString()}</li>
-            <li>{t('plans.detail_billing')}: {detail.billingCycle.toString()}s</li>
+            <li>
+              {t('plans.detail_price')}: 
+              <Price amount={detail.price} decimals={detail.tokenDecimals} symbol={detail.token} />
+            </li>
+            <li>
+              {t('plans.detail_billing')}: 
+              {detail.billingCycle % 86400n === 0n
+                ? `${detail.billingCycle / 86400n}\u202Fd`
+                : `${detail.billingCycle.toString()}s`}
+            </li>
             <li>{t('plans.detail_active')}: {detail.active ? 'true' : 'false'}</li>
           </ul>
         </div>

--- a/frontend/lib/Price.tsx
+++ b/frontend/lib/Price.tsx
@@ -1,0 +1,13 @@
+'use client';
+import { formatUnits } from 'ethers';
+
+export interface PriceProps {
+  amount: bigint | string;
+  decimals: bigint;
+  symbol: string;
+}
+
+export default function Price({ amount, decimals, symbol }: PriceProps) {
+  const value = typeof amount === 'bigint' ? formatUnits(amount, Number(decimals)) : amount;
+  return <span>{`${value} ${symbol}`}</span>;
+}

--- a/frontend/lib/plansStore.tsx
+++ b/frontend/lib/plansStore.tsx
@@ -1,5 +1,6 @@
 'use client';
 import { createContext, useContext, useEffect, useState } from 'react';
+import { formatUnits } from 'ethers';
 import { getContract } from './contract';
 import { env } from './env';
 
@@ -8,7 +9,7 @@ export interface Plan {
   merchant: string;
   token: string;
   tokenDecimals: bigint;
-  price: bigint;
+  price: string;
   billingCycle: bigint;
   priceInUsd: boolean;
   usdPrice: bigint;
@@ -33,7 +34,18 @@ export function PlansProvider({ children }: { children: React.ReactNode }) {
       const list: Plan[] = [];
       for (let i = 0n; i < nextId; i++) {
         const p = await contract.plans(i);
-        list.push({ id: i, ...(p as Plan) });
+        list.push({
+          id: i,
+          merchant: p.merchant,
+          token: p.token,
+          tokenDecimals: p.tokenDecimals,
+          price: formatUnits(p.price, Number(p.tokenDecimals)),
+          billingCycle: p.billingCycle,
+          priceInUsd: p.priceInUsd,
+          usdPrice: p.usdPrice,
+          priceFeedAddress: p.priceFeedAddress,
+          active: p.active,
+        });
       }
       setPlans(list);
     } catch (err) {


### PR DESCRIPTION
## Summary
- convert plan prices to decimals using `formatUnits`
- show prices and billing cycles in human format
- add `Price` helper component
- update unit tests for new formatting

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a67282d988333845f32938d4e76e0