### PR TITLE
Add graph configuration file support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ frontend/.env.local
 # Generated subgraph files
 subgraph/subgraph.local.yaml
 subgraph/generated/
+subgraph/graph.config.json

--- a/docs/usage-examples.md
+++ b/docs/usage-examples.md
@@ -97,11 +97,16 @@ curl -X POST http://localhost:8000/subgraphs/name/subscription-subgraph/graphql 
 ### Environment Variables
 
 `npm run prepare-subgraph` and `npm run build-subgraph` read the following
-variables:
+variables. Missing values can also be provided in `subgraph/graph.config.json`:
 
 - `NETWORK` – network name used when preparing the manifest
 - `CONTRACT_ADDRESS` – address of the deployed contract
 - `NEXT_PUBLIC_SUBGRAPH_URL` – GraphQL endpoint consumed by the frontend
+
+Create `subgraph/graph.config.json` from `graph.config.example.json` and set
+`GRAPH_NODE_URL`, `IPFS_URL` and `SUBGRAPH_NAME` to avoid exporting these
+variables each time. Both `prepare-subgraph` and `deploy-subgraph` load this
+file automatically when present.
 
 Export them in your shell or provide `--network` and `--address` on the command
 line. To connect the frontend create `frontend/.env.local` with:
@@ -115,8 +120,9 @@ synced.
 
 ## Deploying to a Hosted Graph Node
 
-If you run a Graph Node on a remote server, set `GRAPH_NODE_URL` and `IPFS_URL`
-(and optionally `GRAPH_ACCESS_TOKEN` and `SUBGRAPH_VERSION`) and run:
+If you run a Graph Node on a remote server, set `GRAPH_NODE_URL` and
+`IPFS_URL` (or define them in `subgraph/graph.config.json`). Optionally set
+`GRAPH_ACCESS_TOKEN` and `SUBGRAPH_VERSION` and run:
 
 ```bash
 npm run deploy-subgraph

--- a/scripts/deploy-subgraph.ts
+++ b/scripts/deploy-subgraph.ts
@@ -1,5 +1,21 @@
 import { spawnSync } from 'child_process';
 import { config } from 'dotenv';
+import fs from 'fs';
+import path from 'path';
+
+function loadGraphConfig() {
+  const cfg = path.join(__dirname, '../subgraph/graph.config.json');
+  if (fs.existsSync(cfg)) {
+    try {
+      const data = JSON.parse(fs.readFileSync(cfg, 'utf8')) as Record<string, string>;
+      for (const [key, value] of Object.entries(data)) {
+        if (!process.env[key]) process.env[key] = value;
+      }
+    } catch (err) {
+      console.warn(`Failed to parse ${cfg}: ${(err as Error).message}`);
+    }
+  }
+}
 
 /**
  * Build and deploy the subgraph using `graph deploy`.
@@ -77,5 +93,6 @@ function main() {
 
 if (require.main === module) {
   config();
+  loadGraphConfig();
   main();
 }

--- a/scripts/prepare-subgraph.ts
+++ b/scripts/prepare-subgraph.ts
@@ -1,6 +1,20 @@
 import fs from 'fs';
 import path from 'path';
 
+function loadGraphConfig() {
+  const cfg = path.join(__dirname, '../subgraph/graph.config.json');
+  if (fs.existsSync(cfg)) {
+    try {
+      const data = JSON.parse(fs.readFileSync(cfg, 'utf8')) as Record<string, string>;
+      for (const [key, value] of Object.entries(data)) {
+        if (!process.env[key]) process.env[key] = value;
+      }
+    } catch (err) {
+      console.warn(`Failed to parse ${cfg}: ${(err as Error).message}`);
+    }
+  }
+}
+
 function parseArgs() {
   const result: { network?: string; address?: string } = {};
   const args = process.argv.slice(2);
@@ -28,6 +42,7 @@ function parseArgs() {
   return result;
 }
 
+loadGraphConfig();
 const { network: networkArg, address: addressArg } = parseArgs();
 
 function detectNetwork(): string | undefined {

--- a/subgraph/graph.config.example.json
+++ b/subgraph/graph.config.example.json
@@ -1,0 +1,5 @@
+{
+  "GRAPH_NODE_URL": "http://localhost:8020",
+  "IPFS_URL": "http://localhost:5001",
+  "SUBGRAPH_NAME": "subscription-subgraph"
+}


### PR DESCRIPTION
## Summary
- provide `subgraph/graph.config.example.json` for subgraph deployment settings
- load optional `graph.config.json` in prepare and deploy scripts
- document the new workflow in usage examples
- ignore `graph.config.json`

## Testing
- `npm run lint` *(fails: ESLint couldn't find the plugin `@typescript-eslint/eslint-plugin`)*
- `npm test` *(fails: `hardhat` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a771bac1c8333a7a9be0289d2c6cf