### PR TITLE
Improve plan management accessibility

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -22,6 +22,7 @@ body {
   font-family: Arial, Helvetica, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  line-height: 1.4;
 }
 
 .form {
@@ -29,6 +30,7 @@ body {
   flex-direction: column;
   gap: 8px;
   max-width: 400px;
+  margin: 0 auto;
 }
 
 .form input[type="text"],
@@ -45,6 +47,10 @@ body {
   color: white;
   cursor: pointer;
   border-radius: 4px;
+}
+.form button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
 }
 
 .message-bar {
@@ -70,6 +76,8 @@ body {
 .list {
   margin-top: 12px;
   line-height: 1.5;
+  list-style: none;
+  padding-left: 0;
 }
 
 * {

--- a/frontend/app/manage/page.tsx
+++ b/frontend/app/manage/page.tsx
@@ -33,7 +33,7 @@ export default function Manage() {
       if (!/^[0-9]+$/.test(planId)) throw new Error('invalid plan id');
       const tx = await contractSubscribe(BigInt(planId));
       await tx.wait();
-      setMessage({ text: `Subscribed! Tx: ${tx.hash}`, type: 'success' });
+      setMessage({ text: t('messages.subscribed', { hash: tx.hash }), type: 'success' });
     } catch (err) {
       console.error(err);
       setError(err instanceof Error ? err.message : String(err));
@@ -49,7 +49,7 @@ export default function Manage() {
       if (!/^[0-9]+$/.test(planId)) throw new Error('invalid plan id');
       const tx = await contractCancel(BigInt(planId));
       await tx.wait();
-      setMessage({ text: `Cancelled! Tx: ${tx.hash}`, type: 'success' });
+      setMessage({ text: t('messages.cancelled', { hash: tx.hash }), type: 'success' });
     } catch (err) {
       console.error(err);
       setError(err instanceof Error ? err.message : String(err));
@@ -127,7 +127,7 @@ export default function Manage() {
         s as `0x${string}`
       );
       await tx.wait();
-      setMessage({ text: `Subscribed with permit! Tx: ${tx.hash}`, type: 'success' });
+      setMessage({ text: t('messages.subscribed_permit', { hash: tx.hash }), type: 'success' });
     } catch (err) {
       console.error(err);
       const message = err instanceof Error ? err.message : String(err);
@@ -138,7 +138,7 @@ export default function Manage() {
   }
 
   return (
-    <div>
+    <div aria-busy={loading}>
       <h1>{t('manage.title')}</h1>
       {subs.length > 0 && (
         <ul className="list" data-testid="subs-list">
@@ -150,7 +150,7 @@ export default function Manage() {
         </ul>
       )}
       {error && <p className="error">{error}</p>}
-      {loading && <p>{t('manage.processing')}</p>}
+      {loading && <p aria-live="polite">{t('manage.processing')}</p>}
       {!account && <button onClick={connect}>{t('generic.connect_wallet')}</button>}
       <div>
         <label htmlFor="plan-id">{t('manage.plan_id')} </label>

--- a/frontend/app/plans/create/page.tsx
+++ b/frontend/app/plans/create/page.tsx
@@ -43,7 +43,7 @@ export default function CreatePlan() {
         feed || '0x0000000000000000000000000000000000000000'
       );
       await tx.wait();
-      setMessage({ text: `Plan created: ${tx.hash}`, type: 'success' });
+      setMessage({ text: t('messages.plan_created', { hash: tx.hash }), type: 'success' });
     } catch (err) {
       console.error(err);
       setError(err instanceof Error ? err.message : String(err));
@@ -53,8 +53,9 @@ export default function CreatePlan() {
   }
 
   return (
-    <div className="form">
+    <div className="form" aria-busy={loading}>
       <h1>{t('create.title')}</h1>
+      {loading && <p aria-live="polite">{t('manage.processing')}</p>}
       {error && <p className="error">{error}</p>}
       {!account && <button onClick={connect}>{t('generic.connect_wallet')}</button>}
       <label htmlFor="merchant">{t('create.merchant')}</label>

--- a/frontend/app/plans/manage/page.tsx
+++ b/frontend/app/plans/manage/page.tsx
@@ -33,7 +33,7 @@ export default function ManagePlans() {
         '0x0000000000000000000000000000000000000000',
       );
       await tx.wait();
-      setMessage({ text: 'Plan updated', type: 'success' });
+      setMessage({ text: t('messages.plan_updated'), type: 'success' });
       await reload();
     } catch (err) {
       console.error(err);
@@ -51,7 +51,7 @@ export default function ManagePlans() {
       validateAddress(merchant, 'Merchant');
       const tx = await updateMerchant(BigInt(selected), merchant);
       await tx.wait();
-      setMessage({ text: 'Merchant updated', type: 'success' });
+      setMessage({ text: t('messages.merchant_updated'), type: 'success' });
       await reload();
     } catch (err) {
       console.error(err);
@@ -68,7 +68,7 @@ export default function ManagePlans() {
     try {
       const tx = await disablePlan(BigInt(selected));
       await tx.wait();
-      setMessage({ text: 'Plan disabled', type: 'success' });
+      setMessage({ text: t('messages.plan_disabled'), type: 'success' });
       await reload();
     } catch (err) {
       console.error(err);
@@ -80,8 +80,9 @@ export default function ManagePlans() {
 
   const { t } = useTranslation();
   return (
-    <div className="form">
+    <div className="form" aria-busy={loading}>
       <h1>{t('manage_plans.title')}</h1>
+      {loading && <p aria-live="polite">{t('manage.processing')}</p>}
       {!account && <button onClick={connect}>{t('generic.connect_wallet')}</button>}
       {error && <p className="error">{error}</p>}
       <label htmlFor="plan-select">{t('manage_plans.select_plan')}</label>

--- a/frontend/app/plans/page.tsx
+++ b/frontend/app/plans/page.tsx
@@ -26,10 +26,10 @@ export default function Plans() {
 
   const { t } = useTranslation();
   return (
-    <div>
+    <div aria-busy={loading}>
       <h1>{t('plans.title')}</h1>
       {error && <p className="error">{error}</p>}
-      {loading && <p>{t('generic.loading')}</p>}
+      {loading && <p aria-live="polite">{t('generic.loading')}</p>}
       {!account && <button onClick={connect}>{t('generic.connect_wallet')}</button>}
       <div style={{ marginBottom: 10 }}>
         <a href="/plans/create">{t('nav.create_plan')}</a> |{' '}
@@ -61,7 +61,11 @@ export default function Plans() {
       <ul className="list">
         {sorted.map((p) => (
           <li key={p.id.toString()}>
-            <button onClick={() => setSelected(p.id)}>
+            <button
+              onClick={() => setSelected(p.id)}
+              aria-expanded={selected === p.id}
+              aria-controls="plan-details"
+            >
               {`Plan ${p.id.toString()}: `}
               <Price amount={p.price} decimals={p.tokenDecimals} symbol={p.token} />
               {` alle ${
@@ -74,7 +78,7 @@ export default function Plans() {
         ))}
       </ul>
       {detail && (
-        <div data-testid="plan-details">
+        <div id="plan-details" data-testid="plan-details">
           <h2>{t('plans.details_title')}</h2>
           <ul className="list">
             <li>{t('plans.detail_id')}: {detail.id.toString()}</li>

--- a/frontend/app/plans/update-merchant/page.tsx
+++ b/frontend/app/plans/update-merchant/page.tsx
@@ -23,7 +23,7 @@ export default function UpdateMerchant() {
       validateAddress(merchant, 'Merchant');
       const tx = await updateMerchant(BigInt(planId), merchant);
       await tx.wait();
-      setMessage({ text: `Merchant updated: ${tx.hash}`, type: 'success' });
+      setMessage({ text: t('messages.merchant_updated_hash', { hash: tx.hash }), type: 'success' });
     } catch (err) {
       console.error(err);
       setError(err instanceof Error ? err.message : String(err));
@@ -33,8 +33,9 @@ export default function UpdateMerchant() {
   }
 
   return (
-    <div className="form">
+    <div className="form" aria-busy={loading}>
       <h1>{t('update_merchant.title')}</h1>
+      {loading && <p aria-live="polite">{t('manage.processing')}</p>}
       {error && <p className="error">{error}</p>}
       {!account && <button onClick={connect}>{t('generic.connect_wallet')}</button>}
       <label htmlFor="merchant-plan-id">{t('update_merchant.plan_id')}</label>

--- a/frontend/app/plans/update/page.tsx
+++ b/frontend/app/plans/update/page.tsx
@@ -41,7 +41,7 @@ export default function UpdatePlan() {
         feed || '0x0000000000000000000000000000000000000000'
       );
       await tx.wait();
-      setMessage({ text: `Plan updated: ${tx.hash}`, type: 'success' });
+      setMessage({ text: t('messages.plan_updated_hash', { hash: tx.hash }), type: 'success' });
     } catch (err) {
       console.error(err);
       setError(err instanceof Error ? err.message : String(err));
@@ -51,8 +51,9 @@ export default function UpdatePlan() {
   }
 
   return (
-    <div className="form">
+    <div className="form" aria-busy={loading}>
       <h1>{t('update_plan.title')}</h1>
+      {loading && <p aria-live="polite">{t('manage.processing')}</p>}
       {error && <p className="error">{error}</p>}
       {!account && <button onClick={connect}>{t('generic.connect_wallet')}</button>}
       <label htmlFor="update-plan-id">{t('update_plan.plan_id')}</label>

--- a/frontend/public/locales/de/common.json
+++ b/frontend/public/locales/de/common.json
@@ -78,5 +78,17 @@
   "analytics.plan_totals": "Plan-Gesamtbeträge",
   "analytics.no_plans": "Keine Pläne",
   "analytics.payments": "Zahlungen",
-  "analytics.no_payments": "Keine Zahlungen"
+  "analytics.no_payments": "Keine Zahlungen",
+  "messages.plan_created": "Plan erstellt: {{hash}}",
+  "messages.plan_updated_hash": "Plan aktualisiert: {{hash}}",
+  "messages.plan_updated": "Plan aktualisiert",
+  "messages.merchant_updated_hash": "Händler aktualisiert: {{hash}}",
+  "messages.merchant_updated": "Händler aktualisiert",
+  "messages.plan_disabled": "Plan deaktiviert",
+  "messages.subscribed": "Abonniert! Tx: {{hash}}",
+  "messages.subscribed_permit": "Mit Permit abonniert! Tx: {{hash}}",
+  "messages.cancelled": "Gekündigt! Tx: {{hash}}",
+  "messages.payment_processed": "Zahlung durchgeführt! Tx: {{hash}}",
+  "messages.wallet_not_found": "Wallet nicht gefunden",
+  "messages.failed_connect": "Verbindung fehlgeschlagen"
 }

--- a/frontend/public/locales/en/common.json
+++ b/frontend/public/locales/en/common.json
@@ -78,5 +78,17 @@
   "analytics.plan_totals": "Plan Totals",
   "analytics.no_plans": "No plans",
   "analytics.payments": "Payments",
-  "analytics.no_payments": "No payments"
+  "analytics.no_payments": "No payments",
+  "messages.plan_created": "Plan created: {{hash}}",
+  "messages.plan_updated_hash": "Plan updated: {{hash}}",
+  "messages.plan_updated": "Plan updated",
+  "messages.merchant_updated_hash": "Merchant updated: {{hash}}",
+  "messages.merchant_updated": "Merchant updated",
+  "messages.plan_disabled": "Plan disabled",
+  "messages.subscribed": "Subscribed! Tx: {{hash}}",
+  "messages.subscribed_permit": "Subscribed with permit! Tx: {{hash}}",
+  "messages.cancelled": "Cancelled! Tx: {{hash}}",
+  "messages.payment_processed": "Payment processed! Tx: {{hash}}",
+  "messages.wallet_not_found": "Wallet not found",
+  "messages.failed_connect": "Failed to connect"
 }


### PR DESCRIPTION
## Summary
- improve plan forms with loading state and ARIA attributes
- add translations for user messages
- tweak global CSS for consistent layout

## Testing
- `npm run lint` *(fails: Unexpected any in NetworkStatus.tsx)*
- `npm test` *(fails to run jest suites)*

------
https://chatgpt.com/codex/tasks/task_e_686a7718a96c8333842f92a3f336fd94