### PR TITLE
Add coverage and slither jobs to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,10 @@ jobs:
         run: npm ci
       - name: Run unit tests
         run: npm test
+      - name: Run coverage
+        run: npm run coverage
+      - name: Check coverage threshold
+        run: node scripts/check-coverage.js
       - name: Run subgraph tests
         run: npm run test-subgraph
       - name: Run e2e tests
@@ -32,12 +36,6 @@ jobs:
         run: npm run lint
       - name: Run Solhint
         run: npm run solhint
-      - name: Run Slither
-        run: npm run slither
-      - name: Run coverage
-        run: npm run coverage
-      - name: Check coverage threshold
-        run: npm run coverage-check
       - name: Upload coverage report
         uses: actions/upload-artifact@v4
         with:
@@ -54,3 +52,24 @@ jobs:
         with:
           name: frontend-coverage
           path: frontend/coverage
+
+  slither:
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: package-lock.json
+      - name: Install dependencies
+        run: npm ci
+      - name: Run Slither
+        run: npm run slither
+      - name: Upload slither output
+        uses: actions/upload-artifact@v4
+        with:
+          name: slither-output
+          path: docs/slither-output.txt

--- a/docs/production-guide.md
+++ b/docs/production-guide.md
@@ -95,3 +95,15 @@ scrape_configs:
 ```
 
 Grafana can visualize these metrics using Prometheus as the data source. Alert on `graph_node_health_failures_total` or when `graph_node_health_status` stays `0` for several minutes.
+
+## Continuous Integration
+
+The repository includes a GitHub Actions workflow `ci.yml` which runs tests and
+static analysis automatically. After the `npm test` step the workflow executes
+`npm run coverage` and validates the results using `node
+scripts/check-coverage.js`. The minimum percentage can be configured via the
+`COVERAGE_THRESHOLD` environment variable.
+
+Slither executes in a separate job through `npm run slither`. The job uploads
+`docs/slither-output.txt` as an artifact so warnings can be reviewed in the
+GitHub interface.


### PR DESCRIPTION
## Summary
- run coverage right after the unit tests
- verify coverage via `node scripts/check-coverage.js`
- create separate job for Slither and upload its report
- document the CI steps in the production guide

## Testing
- `npm ci` *(fails: ERESOLVE could not resolve)*

------
https://chatgpt.com/codex/tasks/task_e_686a9cb25c1c8333895a6cb1096483e8