### PR TITLE
Add JSON output and improved CLI error handling

### DIFF
--- a/docs/cli-guide.md
+++ b/docs/cli-guide.md
@@ -1,12 +1,22 @@
 # CLI Guide
 
 This guide shows common ways to invoke `scripts/cli.ts` using `ts-node`.
-All commands support the `--network` flag to select a Hardhat network.
+All commands support the `--network` flag to select a Hardhat network. Use
+`--json` to get structured JSON output instead of formatted text.
+
+If a required parameter or environment variable is missing the CLI prints an
+error message and exits with code `1`.
 
 ## List existing plans
 
 ```bash
 npx ts-node scripts/cli.ts list --subscription <address> --network hardhat
+```
+
+Structured JSON output:
+
+```bash
+npx ts-node scripts/cli.ts list --subscription <address> --network hardhat --json
 ```
 
 ## Create a new plan
@@ -19,6 +29,18 @@ npx ts-node scripts/cli.ts create \
   --price 1000 \
   --billing-cycle 3600 \
   --network hardhat
+```
+
+Add `--json` to receive the transaction hash as JSON.
+
+```bash
+npx ts-node scripts/cli.ts create \
+  --subscription <address> \
+  --merchant <merchant> \
+  --token <erc20> \
+  --price 1000 \
+  --billing-cycle 3600 \
+  --network hardhat --json
 ```
 
 ## Update a plan

--- a/scripts/cli.test.ts
+++ b/scripts/cli.test.ts
@@ -33,7 +33,15 @@ describe('cli.ts', function () {
 
   it('fails when subscription is missing', function () {
     const res = run(['list']);
-    expect(res.status).to.not.equal(0);
+    expect(res.status).to.equal(1);
     expect(res.stderr).to.match(/subscription address missing/i);
+  });
+
+  it('returns json error with --json', function () {
+    const res = run(['list', '--json']);
+    expect(res.status).to.equal(1);
+    const lines = res.stderr.trim().split(/\r?\n/);
+    const obj = JSON.parse(lines[lines.length - 1]);
+    expect(obj.error).to.match(/subscription address missing/i);
   });
 });


### PR DESCRIPTION
## Summary
- exit with code 1 on invalid parameters or missing env variables
- add `--json` option for structured output
- update examples in `docs/cli-guide.md`
- adjust CLI tests

## Testing
- `npm run test:cli`

------
https://chatgpt.com/codex/tasks/task_e_686a9cb2fad08333985d0a6523155564