### PR TITLE
Modernize UI with Radix Form

### DIFF
--- a/frontend/__tests__/Manage.test.tsx
+++ b/frontend/__tests__/Manage.test.tsx
@@ -42,6 +42,10 @@ function Wrapper() {
   );
 }
 
+beforeEach(() => {
+  mockUseSubs.mockReturnValue({ subs: [], reload: jest.fn() });
+});
+
 test('shows message when subscribe fails', async () => {
   mockedSubscribe.mockRejectedValue(new Error('fail'));
   render(<Wrapper />);

--- a/frontend/__tests__/PlansPage.test.tsx
+++ b/frontend/__tests__/PlansPage.test.tsx
@@ -35,9 +35,9 @@ describe('Plans page', () => {
       reload: jest.fn(),
     });
     render(<Wrapper />);
-    const btn = screen.getByText(
-      'Plan 0: 0.000000000000000001 a alle 1s (active)',
-    );
+    const btn = screen.getByRole('button', {
+      name: /Plan 0: 0\.000000000000000001 a alle 1s \(active\)/,
+    });
     expect(btn).toBeInTheDocument();
     await userEvent.click(btn);
     expect(await screen.findByTestId('plan-details')).toBeInTheDocument();

--- a/frontend/__tests__/Snapshots.test.tsx
+++ b/frontend/__tests__/Snapshots.test.tsx
@@ -1,0 +1,40 @@
+import { render } from '@testing-library/react';
+import Manage from '../app/manage/page';
+import Payment from '../app/payment/page';
+import Plans from '../app/plans/page';
+import { StoreProvider } from '../lib/store';
+
+jest.mock('../lib/useWallet', () => () => ({ account: '0xabc', connect: jest.fn() }));
+jest.mock('../lib/plansStore', () => ({ usePlans: () => ({ plans: [], reload: jest.fn() }) }));
+jest.mock('../lib/useUserSubscriptions', () => () => ({ subs: [], reload: jest.fn() }));
+
+function Wrapper({ children }: { children: React.ReactNode }) {
+  return <StoreProvider>{children}</StoreProvider>;
+}
+
+test('manage page snapshot', () => {
+  const { asFragment } = render(
+    <Wrapper>
+      <Manage />
+    </Wrapper>
+  );
+  expect(asFragment()).toMatchSnapshot();
+});
+
+test('plans page snapshot', () => {
+  const { asFragment } = render(
+    <Wrapper>
+      <Plans />
+    </Wrapper>
+  );
+  expect(asFragment()).toMatchSnapshot();
+});
+
+test('payment page snapshot', () => {
+  const { asFragment } = render(
+    <Wrapper>
+      <Payment />
+    </Wrapper>
+  );
+  expect(asFragment()).toMatchSnapshot();
+});

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -1,12 +1,16 @@
 :root {
   --background: #ffffff;
   --foreground: #171717;
+  --accent: #4a90e2;
+  --accent-alt: #356ac3;
 }
 
 @media (prefers-color-scheme: dark) {
   :root {
     --background: #0a0a0a;
     --foreground: #ededed;
+    --accent: #3399ff;
+    --accent-alt: #2277cc;
   }
 }
 
@@ -29,7 +33,9 @@ body {
   display: flex;
   flex-direction: column;
   gap: 8px;
+  width: 100%;
   max-width: 400px;
+  padding: 0 1rem;
   margin: 0 auto;
 }
 
@@ -40,17 +46,33 @@ body {
   border-radius: 4px;
 }
 
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+@media (min-width: 600px) {
+  .form {
+    max-width: 500px;
+  }
+}
+
 .form button {
   padding: 6px 12px;
   border: none;
-  background: #4a90e2;
+  background: var(--accent);
   color: white;
   cursor: pointer;
   border-radius: 4px;
+  transition: background 0.2s ease-in-out;
 }
 .form button:disabled {
   opacity: 0.6;
   cursor: not-allowed;
+}
+.form button:not(:disabled):hover {
+  background: var(--accent-alt);
 }
 
 .message-bar {

--- a/frontend/app/manage/page.tsx
+++ b/frontend/app/manage/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 import { useState } from 'react';
+import * as Form from '@radix-ui/react-form';
 import { ethers } from 'ethers';
 import {
   getContract,
@@ -11,6 +12,7 @@ import { AggregatorV3Interface__factory } from 'typechain/factories/contracts/in
 import useWallet from '../../lib/useWallet';
 import { useStore } from '../../lib/store';
 import useUserSubscriptions from '../../lib/useUserSubscriptions';
+import InputField from '../../lib/InputField';
 import { useTranslation } from 'react-i18next';
 
 export default function Manage() {
@@ -152,38 +154,25 @@ export default function Manage() {
       {error && <p className="error">{error}</p>}
       {loading && <p aria-live="polite">{t('manage.processing')}</p>}
       {!account && <button onClick={connect}>{t('generic.connect_wallet')}</button>}
-      <div>
-        <label htmlFor="plan-id">{t('manage.plan_id')} </label>
-        <input
-          id="plan-id"
-          value={planId}
-          onChange={(e) => setPlanId(e.target.value)}
-        />
-      </div>
-      <div>
-        <label htmlFor="deadline">{t('manage.deadline')} </label>
-        <input
-          id="deadline"
-          value={deadline}
-          onChange={(e) => setDeadline(e.target.value)}
-        />
-      </div>
-      <div>
-        <label htmlFor="sig-v">{t('manage.v')} </label>
-        <input id="sig-v" value={v} onChange={(e) => setV(e.target.value)} />
-      </div>
-      <div>
-        <label htmlFor="sig-r">{t('manage.r')} </label>
-        <input id="sig-r" value={r} onChange={(e) => setR(e.target.value)} />
-      </div>
-      <div>
-        <label htmlFor="sig-s">{t('manage.s')} </label>
-        <input id="sig-s" value={s} onChange={(e) => setS(e.target.value)} />
-      </div>
-      <button onClick={requestPermit} disabled={loading || !account}>{t('manage.get_permit')}</button>
-      <button onClick={subscribePermit} disabled={loading}>{t('manage.subscribe_permit')}</button>
-      <button onClick={subscribe} disabled={loading}>{t('manage.subscribe')}</button>
-      <button onClick={cancel} disabled={loading}>{t('manage.cancel')}</button>
+      <Form.Root className="form" onSubmit={(e) => { e.preventDefault(); subscribe(); }}>
+        <InputField name="plan-id" label={t('manage.plan_id')} value={planId} onChange={setPlanId} />
+        <InputField name="deadline" label={t('manage.deadline')} value={deadline} onChange={setDeadline} />
+        <InputField name="sig-v" label={t('manage.v')} value={v} onChange={setV} />
+        <InputField name="sig-r" label={t('manage.r')} value={r} onChange={setR} />
+        <InputField name="sig-s" label={t('manage.s')} value={s} onChange={setS} />
+        <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
+          <button type="button" onClick={requestPermit} disabled={loading || !account}>
+            {t('manage.get_permit')}
+          </button>
+          <button type="button" onClick={subscribePermit} disabled={loading}>
+            {t('manage.subscribe_permit')}
+          </button>
+          <Form.Submit disabled={loading}>{t('manage.subscribe')}</Form.Submit>
+          <button type="button" onClick={cancel} disabled={loading}>
+            {t('manage.cancel')}
+          </button>
+        </div>
+      </Form.Root>
     </div>
   );
 }

--- a/frontend/app/payment/page.tsx
+++ b/frontend/app/payment/page.tsx
@@ -1,9 +1,11 @@
 'use client';
 import { useState } from 'react';
+import * as Form from '@radix-ui/react-form';
 import { processPayment as contractProcessPayment } from '../../lib/contract';
 import useWallet from '../../lib/useWallet';
 import { useStore } from '../../lib/store';
 import { useTranslation } from 'react-i18next';
+import InputField from '../../lib/InputField';
 
 export default function Payment() {
   const { account, connect } = useWallet();
@@ -38,23 +40,11 @@ export default function Payment() {
       {error && <p className="error">{error}</p>}
       {loading && <p>{t('manage.processing')}</p>}
       {!account && <button onClick={connect}>{t('generic.connect_wallet')}</button>}
-      <div>
-        <label htmlFor="pay-user">{t('payment.user')} </label>
-        <input
-          id="pay-user"
-          value={user}
-          onChange={(e) => setUser(e.target.value)}
-        />
-      </div>
-      <div>
-        <label htmlFor="pay-plan">{t('payment.plan_id')} </label>
-        <input
-          id="pay-plan"
-          value={planId}
-          onChange={(e) => setPlanId(e.target.value)}
-        />
-      </div>
-      <button onClick={trigger} disabled={loading}>{t('payment.process')}</button>
+      <Form.Root className="form" onSubmit={(e) => { e.preventDefault(); trigger(); }}>
+        <InputField name="pay-user" label={t('payment.user')} value={user} onChange={setUser} />
+        <InputField name="pay-plan" label={t('payment.plan_id')} value={planId} onChange={setPlanId} />
+        <Form.Submit disabled={loading}>{t('payment.process')}</Form.Submit>
+      </Form.Root>
     </div>
   );
 }

--- a/frontend/app/plans/page.tsx
+++ b/frontend/app/plans/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 import { useState } from 'react';
+import * as Form from '@radix-ui/react-form';
 import { usePlans } from '../../lib/plansStore';
 import useWallet from '../../lib/useWallet';
 import { useTranslation } from 'react-i18next';
@@ -35,29 +36,40 @@ export default function Plans() {
         <a href="/plans/create">{t('nav.create_plan')}</a> |{' '}
         <a href="/plans/manage">{t('nav.manage_plans')}</a>
       </div>
-      <label htmlFor="filter">{t('plans.filter')}</label>
-      <select
-        id="filter"
-        value={filter}
-        onChange={(e) =>
-          setFilter(e.target.value as 'all' | 'active' | 'inactive')
-        }
-        style={{ marginLeft: 4, marginRight: 10 }}
+      <Form.Root
+        onSubmit={(e) => e.preventDefault()}
+        style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap', marginBottom: 10 }}
       >
-        <option value="all">{t('plans.filter_all')}</option>
-        <option value="active">{t('plans.filter_active')}</option>
-        <option value="inactive">{t('plans.filter_inactive')}</option>
-      </select>
-      <label htmlFor="sort">{t('plans.sort')}</label>
-      <select
-        id="sort"
-        value={sort}
-        onChange={(e) => setSort(e.target.value as 'asc' | 'desc')}
-        style={{ marginLeft: 4 }}
-      >
-        <option value="asc">{t('plans.sort_asc')}</option>
-        <option value="desc">{t('plans.sort_desc')}</option>
-      </select>
+        <Form.Field name="filter" className="field">
+          <Form.Label htmlFor="filter">{t('plans.filter')}</Form.Label>
+          <Form.Control asChild>
+            <select
+              id="filter"
+              value={filter}
+              onChange={(e) =>
+                setFilter(e.target.value as 'all' | 'active' | 'inactive')
+              }
+            >
+              <option value="all">{t('plans.filter_all')}</option>
+              <option value="active">{t('plans.filter_active')}</option>
+              <option value="inactive">{t('plans.filter_inactive')}</option>
+            </select>
+          </Form.Control>
+        </Form.Field>
+        <Form.Field name="sort" className="field">
+          <Form.Label htmlFor="sort">{t('plans.sort')}</Form.Label>
+          <Form.Control asChild>
+            <select
+              id="sort"
+              value={sort}
+              onChange={(e) => setSort(e.target.value as 'asc' | 'desc')}
+            >
+              <option value="asc">{t('plans.sort_asc')}</option>
+              <option value="desc">{t('plans.sort_desc')}</option>
+            </select>
+          </Form.Control>
+        </Form.Field>
+      </Form.Root>
       <ul className="list">
         {sorted.map((p) => (
           <li key={p.id.toString()}>

--- a/frontend/jest.setup.ts
+++ b/frontend/jest.setup.ts
@@ -6,6 +6,11 @@ import { TextEncoder, TextDecoder } from 'util';
 jest.mock('@coinbase/wallet-sdk', () => {
   return jest.fn().mockImplementation(() => ({ makeWeb3Provider: jest.fn() }));
 });
+// Provide simple i18n mock
+import en from './public/locales/en/common.json';
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => (en as any)[key] || key }),
+}));
 process.env.NEXT_PUBLIC_CONTRACT_ADDRESS = '0x0000000000000000000000000000000000000000';
 process.env.NEXT_PUBLIC_CHAIN_ID = '1';
 process.env.NEXT_PUBLIC_RPC_URL = 'http://localhost:8545';

--- a/frontend/lib/InputField.tsx
+++ b/frontend/lib/InputField.tsx
@@ -1,0 +1,30 @@
+'use client';
+import * as Form from '@radix-ui/react-form';
+
+interface InputFieldProps {
+  name: string;
+  label: string;
+  value: string;
+  onChange: (v: string) => void;
+  type?: string;
+  error?: string | null;
+}
+
+export default function InputField({
+  name,
+  label,
+  value,
+  onChange,
+  type = 'text',
+  error,
+}: InputFieldProps) {
+  return (
+    <Form.Field name={name} className="field">
+      <Form.Label htmlFor={name}>{label}</Form.Label>
+      <Form.Control asChild>
+        <input id={name} value={value} onChange={(e) => onChange(e.target.value)} type={type} />
+      </Form.Control>
+      {error && <Form.Message className="error">{error}</Form.Message>}
+    </Form.Field>
+  );
+}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@apollo/client": "^3.13.8",
         "@coinbase/wallet-sdk": "^4.0.0",
+        "@radix-ui/react-form": "^0.1.7",
         "@walletconnect/web3-provider": "^1.8.0",
         "ethers": "^6.14.4",
         "graphql": "^16.11.0",
@@ -3119,6 +3120,167 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.4.0"
+      }
+    },
+    "node_modules/@radix-ui/primitive": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.2.tgz",
+      "integrity": "sha512-XnbHrrprsNqZKQhStrSwgRUQzoCI1glLzdw79xiZPoofhGICeZRSQ3dIxAKH1gb3OHfNf4d6f+vAv3kil2eggA==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
+      "integrity": "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-context": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
+      "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-form": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-form/-/react-form-0.1.7.tgz",
+      "integrity": "sha512-IXLKFnaYvFg/KkeV5QfOX7tRnwHXp127koOFUjLWMTrRv5Rny3DQcAtIFFeA/Cli4HHM8DuJCXAUsgnFVJndlw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.2",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-label": "2.1.7",
+        "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-id": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.1.tgz",
+      "integrity": "sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-label": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-label/-/react-label-2.1.7.tgz",
+      "integrity": "sha512-YT1GqPSL8kJn20djelMX7/cTRp/Y9w5IZHvfxQTVHrOqa2yMl7i/UfMqKRU5V7mEyKTrUVgJXhNQPVCG8PBLoQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.1.tgz",
+      "integrity": "sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@repeaterjs/repeater": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -26,7 +26,8 @@
     "next-i18next": "^15.4.2",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "react-i18next": "^15.6.0"
+    "react-i18next": "^15.6.0",
+    "@radix-ui/react-form": "^0.1.7"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",


### PR DESCRIPTION
## Summary
- add Radix `InputField` wrapper and extend global styles
- switch subscription, plans and payment pages to Radix Form
- update jest setup with simple i18n mock
- adjust tests and add new snapshot suite

## Testing
- `npm test -- -u` *(fails: Unknown option "coverage" warnings and several test failures)*

------
https://chatgpt.com/codex/tasks/task_e_686a9cb2975c8333896452e9a94da584