### PR TITLE
Document Prometheus metrics

### DIFF
--- a/docs/examples/prometheus.yml
+++ b/docs/examples/prometheus.yml
@@ -1,5 +1,6 @@
 # Example Prometheus configuration
-# Scrapes metrics from the subgraph server on port 9091.
+# Scrapes metrics from the subgraph server on port 9091 and the
+# payment processing script on port 9092.
 
 global:
   scrape_interval: 15s
@@ -8,3 +9,6 @@ scrape_configs:
   - job_name: 'subgraph-server'
     static_configs:
       - targets: ['localhost:9091']
+  - job_name: 'due-payments'
+    static_configs:
+      - targets: ['localhost:9092']

--- a/docs/production-guide.md
+++ b/docs/production-guide.md
@@ -79,19 +79,32 @@ Consider setting up additional service-level monitoring for your contract intera
 ## Monitoring
 
 `scripts/subgraph-server.ts` serves Prometheus metrics on port `9091`.
-Start the server with:
+`scripts/process-due-payments.ts` can expose metrics on port `9092` when
+`METRICS_PORT` is set.
+Start the servers with:
 
 ```bash
+# Graph Node monitoring
 METRICS_PORT=9091 npm run subgraph-server
+
+# Payment metrics
+METRICS_PORT=9092 ts-node scripts/process-due-payments.ts --daemon
 ```
 
-Add a scrape config in your `prometheus.yml`:
+Add scrape configs in your `prometheus.yml`:
 
 ```yaml
 scrape_configs:
   - job_name: 'subgraph-server'
     static_configs:
       - targets: ['localhost:9091']
+  - job_name: 'due-payments'
+    static_configs:
+      - targets: ['localhost:9092']
 ```
 
-Grafana can visualize these metrics using Prometheus as the data source. Alert on `graph_node_health_failures_total` or when `graph_node_health_status` stays `0` for several minutes.
+Grafana visualizes these metrics using Prometheus as the data source.
+Useful alerts include `graph_node_health_failures_total` rising or
+`graph_node_health_status` staying `0` for several minutes. For the
+payment script you may monitor `payment_failure_total` per `plan_id` and
+alert when failures spike.

--- a/scripts/process-due-payments.ts
+++ b/scripts/process-due-payments.ts
@@ -46,6 +46,16 @@ if (configPath) {
 
 const env = loadEnv();
 
+/**
+ * When `METRICS_PORT` is set, the script exposes Prometheus metrics under
+ * `/metrics`.  In addition to the default Node metrics provided by
+ * `prom-client`, two counters are exported:
+ *
+ * - `payment_success_total{plan_id}` – incremented for each successful
+ *   `processPayment` call.
+ * - `payment_failure_total{plan_id}` – incremented when a payment attempt
+ *   fails after all retries.
+ */
 const metricsPort = env.METRICS_PORT ? parseInt(env.METRICS_PORT, 10) : 0;
 let register: Registry | null = null;
 let successCounter: Counter | null = null;

--- a/scripts/subgraph-server.ts
+++ b/scripts/subgraph-server.ts
@@ -37,6 +37,14 @@ const metricsPort = parseInt(env.METRICS_PORT || '9091', 10);
 const log = createLogger({ logFile, lokiUrl, logLevel });
 const register = new Registry();
 collectDefaultMetrics({ register });
+/**
+ * Prometheus metrics exported on `/metrics` when `METRICS_PORT` is set:
+ *
+ * - `graph_node_restarts_total` – number of graph-node restarts.
+ * - `graph_node_health_failures_total` – failed health checks.
+ * - `graph_node_health_status` – gauge set to 1 when the last health
+ *   check succeeded, otherwise 0.
+ */
 const restartCounter = new Counter({
   name: 'graph_node_restarts_total',
   help: 'Total number of graph-node restarts',


### PR DESCRIPTION
## Summary
- document Prometheus counters in payment and subgraph scripts
- extend Prometheus example with payment metrics
- expand production guide with Prometheus/Grafana hints

## Testing
- `npm test` *(fails: hardhat not found)*

------
https://chatgpt.com/codex/tasks/task_e_686aa719ef70833392e02cf4df61ecfc