### PR TITLE
Improve frontend style with theme

### DIFF
--- a/frontend/app/analytics/page.tsx
+++ b/frontend/app/analytics/page.tsx
@@ -68,7 +68,7 @@ export default function Analytics() {
   }
 
   return (
-    <div>
+    <div className="container">
       <h1>{t('analytics.title')}</h1>
       {error && (
         <p className="error">

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
+import "../styles/theme.css";
 import { StoreProvider } from "../lib/store";
 import MessageBar from "../lib/MessageBar";
 import NetworkStatus from "../lib/NetworkStatus";
@@ -34,8 +35,10 @@ export default function RootLayout({
         <I18nProvider>
           <StoreProvider>
             <PlansProvider>
-              <LanguageSwitcher />
-              <NetworkStatus />
+              <div className="top-bar">
+                <LanguageSwitcher />
+                <NetworkStatus />
+              </div>
               <MessageBar />
               {children}
             </PlansProvider>

--- a/frontend/app/manage/page.tsx
+++ b/frontend/app/manage/page.tsx
@@ -140,7 +140,7 @@ export default function Manage() {
   }
 
   return (
-    <div aria-busy={loading}>
+    <div className="container" aria-busy={loading}>
       <h1>{t('manage.title')}</h1>
       {subs.length > 0 && (
         <ul className="list" data-testid="subs-list">
@@ -160,7 +160,7 @@ export default function Manage() {
         <InputField name="sig-v" label={t('manage.v')} value={v} onChange={setV} />
         <InputField name="sig-r" label={t('manage.r')} value={r} onChange={setR} />
         <InputField name="sig-s" label={t('manage.s')} value={s} onChange={setS} />
-        <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
+        <div className="actions">
           <button type="button" onClick={requestPermit} disabled={loading || !account}>
             {t('manage.get_permit')}
           </button>

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -5,9 +5,9 @@ import { useTranslation } from 'react-i18next';
 export default function Home() {
   const { t } = useTranslation();
   return (
-    <div style={{ padding: 20 }}>
+    <div className="container">
       <h1>{t('home.title')}</h1>
-      <ul>
+      <ul className="nav">
         <li>
           <Link href="/plans">{t('nav.plans')}</Link>
         </li>

--- a/frontend/app/payment/page.tsx
+++ b/frontend/app/payment/page.tsx
@@ -35,7 +35,7 @@ export default function Payment() {
   }
 
   return (
-    <div>
+    <div className="container">
       <h1>{t('payment.title')}</h1>
       {error && <p className="error">{error}</p>}
       {loading && <p>{t('manage.processing')}</p>}

--- a/frontend/app/plans/page.tsx
+++ b/frontend/app/plans/page.tsx
@@ -27,18 +27,18 @@ export default function Plans() {
 
   const { t } = useTranslation();
   return (
-    <div aria-busy={loading}>
+    <div className="container" aria-busy={loading}>
       <h1>{t('plans.title')}</h1>
       {error && <p className="error">{error}</p>}
       {loading && <p aria-live="polite">{t('generic.loading')}</p>}
       {!account && <button onClick={connect}>{t('generic.connect_wallet')}</button>}
-      <div style={{ marginBottom: 10 }}>
+      <div className="top-links">
         <a href="/plans/create">{t('nav.create_plan')}</a> |{' '}
         <a href="/plans/manage">{t('nav.manage_plans')}</a>
       </div>
       <Form.Root
         onSubmit={(e) => e.preventDefault()}
-        style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap', marginBottom: 10 }}
+        className="filter-form"
       >
         <Form.Field name="filter" className="field">
           <Form.Label htmlFor="filter">{t('plans.filter')}</Form.Label>

--- a/frontend/lib/LanguageSwitcher.tsx
+++ b/frontend/lib/LanguageSwitcher.tsx
@@ -7,7 +7,7 @@ export default function LanguageSwitcher() {
     i18n.changeLanguage(i18n.language === 'en' ? 'de' : 'en');
   };
   return (
-    <button onClick={toggle} style={{ float: 'right' }}>
+    <button onClick={toggle} className="language-switcher">
       {i18n.language === 'en' ? 'DE' : 'EN'}
     </button>
   );

--- a/frontend/lib/NetworkStatus.tsx
+++ b/frontend/lib/NetworkStatus.tsx
@@ -43,7 +43,7 @@ export default function NetworkStatus() {
   if (!name || block === null) return null;
 
   return (
-    <span className="network-status" style={{ float: 'right', marginLeft: 10 }}>
+    <span className="network-status">
       {name} #{block}
     </span>
   );

--- a/frontend/styles/theme.css
+++ b/frontend/styles/theme.css
@@ -1,0 +1,63 @@
+.container {
+  width: 100%;
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 1rem;
+}
+
+.top-bar {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+  padding: 0.5rem 1rem;
+}
+
+.top-links {
+  margin-bottom: 1rem;
+}
+
+.filter-form {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  margin-bottom: 1rem;
+}
+
+.actions {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.nav {
+  list-style: none;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+@media (min-width: 600px) {
+  .nav {
+    flex-direction: row;
+    flex-wrap: wrap;
+  }
+  .nav li {
+    margin-right: 1rem;
+  }
+}
+
+.language-switcher,
+.network-status {
+  margin-left: 0.5rem;
+}
+
+@media (max-width: 600px) {
+  .container {
+    padding: 0.5rem;
+  }
+  .top-bar {
+    justify-content: center;
+  }
+}


### PR DESCRIPTION
## Summary
- add new stylesheet `styles/theme.css`
- import theme and top bar wrapper in `layout.tsx`
- apply container and nav classes on `page.tsx`
- update plans page layout classes
- style manage actions and other pages
- refactor `LanguageSwitcher` and `NetworkStatus`

## Testing
- `npm install --legacy-peer-deps`
- `npm test` *(fails: Hardhat compilation errors)*

------
https://chatgpt.com/codex/tasks/task_e_686ab09e93788333aca93927c23677a7