### PR TITLE
Add subgraph release version support

### DIFF
--- a/docs/usage-examples.md
+++ b/docs/usage-examples.md
@@ -104,9 +104,9 @@ variables. Missing values can also be provided in `subgraph/graph.config.json`:
 - `NEXT_PUBLIC_SUBGRAPH_URL` – GraphQL endpoint consumed by the frontend
 
 Create `subgraph/graph.config.json` from `graph.config.example.json` and set
-`GRAPH_NODE_URL`, `IPFS_URL` and `SUBGRAPH_NAME` to avoid exporting these
-variables each time. Both `prepare-subgraph` and `deploy-subgraph` load this
-file automatically when present.
+`GRAPH_NODE_URL`, `IPFS_URL`, `SUBGRAPH_NAME` and optionally `SUBGRAPH_VERSION`
+to avoid exporting these variables each time. Both `prepare-subgraph` and
+`deploy-subgraph` load this file automatically when present.
 
 Export them in your shell or provide `--network` and `--address` on the command
 line. To connect the frontend create `frontend/.env.local` with:
@@ -122,7 +122,8 @@ synced.
 
 If you run a Graph Node on a remote server, set `GRAPH_NODE_URL` and
 `IPFS_URL` (or define them in `subgraph/graph.config.json`). Optionally set
-`GRAPH_ACCESS_TOKEN` and `SUBGRAPH_VERSION` and run:
+`GRAPH_ACCESS_TOKEN` and `SUBGRAPH_VERSION` (or pass `--version-label` on the
+command line) and run:
 
 ```bash
 npm run deploy-subgraph

--- a/scripts/deploy-subgraph.ts
+++ b/scripts/deploy-subgraph.ts
@@ -21,8 +21,8 @@ function loadGraphConfig() {
  * Build and deploy the subgraph using `graph deploy`.
  *
  * Example remote deployment:
- * `GRAPH_NODE_URL=https://node.example.com:8020 IPFS_URL=https://node.example.com:5001 ts-node scripts/deploy-subgraph.ts --token <access> --version v1.0.0`
- */
+ * `GRAPH_NODE_URL=https://node.example.com:8020 IPFS_URL=https://node.example.com:5001 ts-node scripts/deploy-subgraph.ts --token <access> --version-label v1.0.0`
+*/
 
 function parseArgs() {
   const result: { version?: string; token?: string } = {};
@@ -30,6 +30,7 @@ function parseArgs() {
   for (let i = 0; i < args.length; i++) {
     const arg = args[i];
     switch (arg) {
+      case '--version-label':
       case '--version':
       case '-v':
         result.version = args[++i];
@@ -39,7 +40,9 @@ function parseArgs() {
         result.token = args[++i];
         break;
       default:
-        if (arg.startsWith('--version=')) {
+        if (arg.startsWith('--version-label=')) {
+          result.version = arg.split('=')[1];
+        } else if (arg.startsWith('--version=')) {
           result.version = arg.split('=')[1];
         } else if (arg.startsWith('--token=')) {
           result.token = arg.split('=')[1];

--- a/subgraph/graph.config.example.json
+++ b/subgraph/graph.config.example.json
@@ -1,5 +1,6 @@
 {
   "GRAPH_NODE_URL": "http://localhost:8020",
   "IPFS_URL": "http://localhost:5001",
-  "SUBGRAPH_NAME": "subscription-subgraph"
+  "SUBGRAPH_NAME": "subscription-subgraph",
+  "SUBGRAPH_VERSION": "v1.0.0"
 }


### PR DESCRIPTION
## Summary
- allow providing a subgraph version via `graph.config.json`
- forward CLI `--version-label` to `graph deploy`
- document new `SUBGRAPH_VERSION` setting

## Testing
- `npm test` *(fails: DocstringParsingError, HH600 Compilation failed)*

------
https://chatgpt.com/codex/tasks/task_e_686ab09fb1788333bb539e3a00728494