### PR TITLE
Add not-found route and test

### DIFF
--- a/frontend/__tests__/NotFound.spec.ts
+++ b/frontend/__tests__/NotFound.spec.ts
@@ -1,0 +1,24 @@
+import { test, expect } from '@playwright/test';
+import { spawn } from 'child_process';
+import path from 'path';
+
+let frontend: any;
+
+test.beforeAll(async () => {
+  frontend = spawn('npm', ['run', 'dev', '--', '-p', '3000'], {
+    cwd: path.join(__dirname, '..'),
+    env: { ...process.env },
+    stdio: 'inherit',
+  });
+  await new Promise(res => setTimeout(res, 10000));
+});
+
+test.afterAll(() => {
+  if (frontend) frontend.kill();
+});
+
+test('renders not found page', async ({ page }) => {
+  await page.goto('/some/unknown/route');
+  await expect(page.getByRole('heading')).toHaveText('Page not found');
+  await expect(page.locator('a[href="/"]')).toBeVisible();
+});

--- a/frontend/app/not-found.tsx
+++ b/frontend/app/not-found.tsx
@@ -1,0 +1,14 @@
+'use client';
+import Link from 'next/link';
+import { useTranslation } from 'react-i18next';
+
+export default function NotFound() {
+  const { t } = useTranslation();
+  return (
+    <div className="container">
+      <h1>{t('not_found.title')}</h1>
+      <p>{t('not_found.description')}</p>
+      <Link href="/">{t('not_found.link_home')}</Link>
+    </div>
+  );
+}

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,0 +1,13 @@
+import type { PlaywrightTestConfig } from '@playwright/test';
+
+const config: PlaywrightTestConfig = {
+  testDir: './__tests__',
+  testMatch: '**/*.spec.ts',
+  timeout: 30000,
+  use: {
+    baseURL: 'http://localhost:3000',
+    headless: true,
+  },
+};
+
+export default config;

--- a/frontend/public/locales/de/common.json
+++ b/frontend/public/locales/de/common.json
@@ -93,5 +93,8 @@
   "messages.failed_connect": "Verbindung fehlgeschlagen",
   "messages.wallet_connected": "Wallet verbunden: {{account}}",
   "messages.transaction_failed": "Transaktion fehlgeschlagen: {{error}}",
-  "messages.dismiss": "Nachricht schließen"
+  "messages.dismiss": "Nachricht schließen",
+  "not_found.title": "Seite nicht gefunden",
+  "not_found.description": "Die angeforderte Seite wurde nicht gefunden.",
+  "not_found.link_home": "Zur Startseite"
 }

--- a/frontend/public/locales/en/common.json
+++ b/frontend/public/locales/en/common.json
@@ -93,5 +93,8 @@
   "messages.failed_connect": "Failed to connect",
   "messages.wallet_connected": "Wallet connected: {{account}}",
   "messages.transaction_failed": "Transaction failed: {{error}}",
-  "messages.dismiss": "Dismiss message"
+  "messages.dismiss": "Dismiss message",
+  "not_found.title": "Page not found",
+  "not_found.description": "The requested page could not be found.",
+  "not_found.link_home": "Back to home"
 }


### PR DESCRIPTION
## Summary
- provide a `not-found.tsx` page in the app folder
- add translations for the 404 page
- configure Playwright for frontend tests and add a simple not-found test

## Testing
- `npm test` *(fails: 3 snapshots failed)*
- `npx playwright test NotFound.spec.ts --config=playwright.config.ts` *(fails: browsers missing)*

------
https://chatgpt.com/codex/tasks/task_e_686af91726388333b13335d91d24b2eb