### PR TITLE
Fix i18n keys and ensure snapshots

### DIFF
--- a/frontend/__tests__/__snapshots__/Snapshots.test.tsx.snap
+++ b/frontend/__tests__/__snapshots__/Snapshots.test.tsx.snap
@@ -4,6 +4,7 @@ exports[`manage page snapshot 1`] = `
 <DocumentFragment>
   <div
     aria-busy="false"
+    class="container"
   >
     <h1>
       Manage Subscription
@@ -92,7 +93,7 @@ exports[`manage page snapshot 1`] = `
         />
       </div>
       <div
-        style="display: flex; gap: 8px; flex-wrap: wrap;"
+        class="actions"
       >
         <button
           type="button"
@@ -122,7 +123,9 @@ exports[`manage page snapshot 1`] = `
 
 exports[`payment page snapshot 1`] = `
 <DocumentFragment>
-  <div>
+  <div
+    class="container"
+  >
     <h1>
       Process Payment
     </h1>
@@ -175,12 +178,13 @@ exports[`plans page snapshot 1`] = `
 <DocumentFragment>
   <div
     aria-busy="false"
+    class="container"
   >
     <h1>
       Available Plans
     </h1>
     <div
-      style="margin-bottom: 10px;"
+      class="top-links"
     >
       <a
         href="/plans/create"
@@ -195,7 +199,7 @@ exports[`plans page snapshot 1`] = `
       </a>
     </div>
     <form
-      style="display: flex; align-items: center; gap: 8px; flex-wrap: wrap; margin-bottom: 10px;"
+      class="filter-form"
     >
       <div
         class="field"

--- a/frontend/app/payment/page.tsx
+++ b/frontend/app/payment/page.tsx
@@ -25,7 +25,7 @@ export default function Payment() {
         throw new Error('invalid plan id');
       const tx = await contractProcessPayment(user, BigInt(planId));
       await tx.wait();
-      setMessage({ text: `Payment processed! Tx: ${tx.hash}`, type: 'success' });
+      setMessage({ text: t('messages.payment_processed', { hash: tx.hash }), type: 'success' });
     } catch (err) {
       console.error(err);
       setError(err instanceof Error ? err.message : String(err));

--- a/frontend/lib/NetworkStatus.tsx
+++ b/frontend/lib/NetworkStatus.tsx
@@ -1,5 +1,6 @@
 'use client';
 import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { ethers } from 'ethers';
 import { env } from './env';
 import { useStore } from './store';
@@ -8,6 +9,7 @@ export default function NetworkStatus() {
   const [name, setName] = useState('');
   const [block, setBlock] = useState<number | null>(null);
   const { setMessage } = useStore();
+  const { t } = useTranslation();
 
   useEffect(() => {
     let cancelled = false;
@@ -26,7 +28,7 @@ export default function NetworkStatus() {
         }
       } catch (err) {
         if (!cancelled) {
-          const msg = err instanceof Error ? err.message : 'Failed to connect';
+          const msg = err instanceof Error ? err.message : t('messages.failed_connect');
           setMessage({ text: msg, type: 'error' });
         }
       }


### PR DESCRIPTION
## Summary
- update Payment page to use `messages.payment_processed`
- translate fallback message in NetworkStatus
- update snapshots after UI changes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686bab16b3cc8333b23b790d007dede0