### PR TITLE
Remove redundant logger type declarations

### DIFF
--- a/scripts/subgraph-server.ts
+++ b/scripts/subgraph-server.ts
@@ -4,9 +4,6 @@ import { loadEnv } from './env';
 import { createLogger, LogFn, LogLevel } from './log';
 import { Counter, Gauge, Registry, collectDefaultMetrics } from 'prom-client';
 
-type LogLevel = 'info' | 'error' | 'warn';
-type LogFn = (level: LogLevel, ...args: any[]) => void;
-
 const env = loadEnv();
 
 const cmd = env.GRAPH_NODE_CMD || 'graph-node';


### PR DESCRIPTION
## Summary
- deduplicate LogLevel and LogFn typings in `subgraph-server.ts`

## Testing
- `npm run compile` *(fails: hardhat not found)*
- `npm run lint` *(fails: missing ESLint plugin)*

------
https://chatgpt.com/codex/tasks/task_e_686bab14d5c48333ac1e5c5848d97155