### PR TITLE
Add metrics CLI test

### DIFF
--- a/scripts/cli.test.ts
+++ b/scripts/cli.test.ts
@@ -6,7 +6,7 @@ function run(args: string[]) {
   return spawnSync(
     'node',
     ['-r', 'ts-node/register/transpile-only', 'scripts/cli.ts', ...args],
-    { encoding: 'utf8' }
+    { encoding: 'utf8' },
   );
 }
 
@@ -20,11 +20,21 @@ describe('cli.ts', function () {
   it('shows help for subcommands', function () {
     expect(run(['list', '--help']).stdout).to.contain('List existing plans');
     expect(run(['create', '--help']).stdout).to.contain('Create a new plan');
-    expect(run(['update', '--help']).stdout).to.contain('Update an existing plan');
-    expect(run(['pause', '--help']).stdout).to.contain('Pause the subscription contract');
-    expect(run(['unpause', '--help']).stdout).to.contain('Unpause the subscription contract');
-    expect(run(['disable', '--help']).stdout).to.contain('Disable a subscription plan');
-    expect(run(['update-merchant', '--help']).stdout).to.contain('Update the merchant of a plan');
+    expect(run(['update', '--help']).stdout).to.contain(
+      'Update an existing plan',
+    );
+    expect(run(['pause', '--help']).stdout).to.contain(
+      'Pause the subscription contract',
+    );
+    expect(run(['unpause', '--help']).stdout).to.contain(
+      'Unpause the subscription contract',
+    );
+    expect(run(['disable', '--help']).stdout).to.contain(
+      'Disable a subscription plan',
+    );
+    expect(run(['update-merchant', '--help']).stdout).to.contain(
+      'Update the merchant of a plan',
+    );
   });
 
   it('shows help for status command', function () {
@@ -47,7 +57,8 @@ describe('cli.ts', function () {
   });
 
   it('summarizes metrics endpoints', async function () {
-    const subMetrics = 'graph_node_restarts_total 2\ngraph_node_health_failures_total 1\n';
+    const subMetrics =
+      'graph_node_restarts_total 2\ngraph_node_health_failures_total 1\n';
     const payMetrics =
       'payment_success_total{plan_id="0"} 3\n' +
       'payment_failure_total{plan_id="0"} 1\n' +
@@ -92,5 +103,52 @@ describe('cli.ts', function () {
     expect(res.stdout).to.match(/restarts:\s*2/);
     expect(res.stdout).to.match(/plan 0: 3 success, 1 failure/);
     expect(res.stdout).to.match(/plan 1: 2 success, 0 failure/);
+  });
+
+  it('summarizes metrics via mocked servers', async function () {
+    const subMetrics =
+      'graph_node_restarts_total 5\n' + 'graph_node_health_failures_total 0\n';
+    const payMetrics =
+      'payment_success_total{plan_id="2"} 7\n' +
+      'payment_failure_total{plan_id="2"} 2\n';
+
+    function startServer(port: number, body: string) {
+      const child = spawn(
+        'node',
+        [
+          '-e',
+          `const http=require('http');\n` +
+            `const metrics=${JSON.stringify(body)};\n` +
+            `const server=http.createServer((req,res)=>{\n` +
+            `  if(req.url==='/metrics') res.end(metrics);\n` +
+            `  else {res.statusCode=404; res.end();}\n` +
+            `});\n` +
+            `server.listen(${port},()=>{console.log('ready');});\n` +
+            `process.on('SIGTERM',()=>server.close(()=>process.exit(0)));`,
+        ],
+        { stdio: ['ignore', 'pipe', 'inherit'] },
+      );
+      return new Promise<{ proc: ReturnType<typeof spawn> }>((resolve) => {
+        child.stdout.once('data', () => resolve({ proc: child }));
+      });
+    }
+
+    const sub = await startServer(9103, subMetrics);
+    const pay = await startServer(9104, payMetrics);
+
+    const res = run([
+      'metrics',
+      '--subgraph',
+      'http://localhost:9103/metrics',
+      '--payments',
+      'http://localhost:9104/metrics',
+    ]);
+
+    sub.proc.kill();
+    pay.proc.kill();
+
+    expect(res.status).to.equal(0);
+    expect(res.stdout).to.match(/restarts:\s*5/);
+    expect(res.stdout).to.match(/plan 2: 7 success, 2 failure/);
   });
 });


### PR DESCRIPTION
## Summary
- add a dedicated test to verify the `metrics` command

## Testing
- `npm run test:cli`

------
https://chatgpt.com/codex/tasks/task_e_686c2ae0d8108333a1c343b7efc47cca