### PR TITLE
Fix ZeroAddress constant

### DIFF
--- a/scripts/deploy.ts
+++ b/scripts/deploy.ts
@@ -8,15 +8,15 @@ async function main() {
   if (!env.MERCHANT_ADDRESS) {
     console.error('MERCHANT_ADDRESS not set, using zero address');
   }
-  const merchant = env.MERCHANT_ADDRESS || ethers.constants.AddressZero;
+  const merchant = env.MERCHANT_ADDRESS || ethers.ZeroAddress;
   if (!env.TOKEN_ADDRESS) {
     console.error('TOKEN_ADDRESS not set, using zero address');
   }
-  const token = env.TOKEN_ADDRESS || ethers.constants.AddressZero;
+  const token = env.TOKEN_ADDRESS || ethers.ZeroAddress;
   if (!env.PRICE_FEED) {
     console.error('PRICE_FEED not set, using zero address');
   }
-  const priceFeed = env.PRICE_FEED || ethers.constants.AddressZero;
+  const priceFeed = env.PRICE_FEED || ethers.ZeroAddress;
   if (!env.BILLING_CYCLE) {
     console.error('BILLING_CYCLE not set, using default 2592000');
   }
@@ -51,7 +51,7 @@ async function main() {
     await subscription.getAddress(),
   );
 
-  if (token !== ethers.constants.AddressZero) {
+  if (token !== ethers.ZeroAddress) {
     const tx = await subscription.createPlan(
       merchant,
       token,

--- a/test/Subscription.ts
+++ b/test/Subscription.ts
@@ -160,7 +160,7 @@ describe("Subscription Contract", function () {
                 0,
                 false,
                 0,
-                ethers.constants.AddressZero
+                ethers.ZeroAddress
             )).to.be.revertedWith("Billing cycle must be > 0");
         });
 
@@ -273,7 +273,7 @@ describe("Subscription Contract", function () {
         it("Reverts when billingCycle is zero", async function () {
             const { subscriptionContract, owner } = await loadFixture(fixtureWithExistingPlan);
             await expect(
-                subscriptionContract.connect(owner).updatePlan(0, 0, 0, false, 0, ethers.constants.AddressZero)
+                subscriptionContract.connect(owner).updatePlan(0, 0, 0, false, 0, ethers.ZeroAddress)
             ).to.be.revertedWith("Billing cycle must be > 0");
         });
 


### PR DESCRIPTION
## Summary
- replace `ethers.constants.AddressZero` with `ethers.ZeroAddress`
- use new constant in deploy script and Subscription tests

## Testing
- `npm run compile`


------
https://chatgpt.com/codex/tasks/task_e_686c5b896e5c83339fbbdfdfc931609d