### PR TITLE
Fix ethers v6 address usage in tests

### DIFF
--- a/test/Subscription.ts
+++ b/test/Subscription.ts
@@ -155,7 +155,7 @@ describe("Subscription Contract", function () {
             const { subscriptionContract, mockToken, owner } = await loadFixture(deploySubscriptionFixture);
             await expect(subscriptionContract.connect(owner).createPlan(
                 owner.address,
-                mockToken.address,
+                mockToken.target,
                 1,
                 0,
                 false,
@@ -536,7 +536,7 @@ describe("Subscription Contract", function () {
             };
             const values = {
                 owner: user1.address,
-                spender: subscription.address,
+                spender: await subscription.getAddress(),
                 value: price,
                 nonce,
                 deadline,
@@ -573,7 +573,7 @@ describe("Subscription Contract", function () {
             };
             const values = {
                 owner: user1.address,
-                spender: subscription.address,
+                spender: await subscription.getAddress(),
                 value: price,
                 nonce,
                 deadline,
@@ -612,7 +612,7 @@ describe("Subscription Contract", function () {
             // Sign with wrong value to invalidate signature
             const values = {
                 owner: user1.address,
-                spender: subscription.address,
+                spender: await subscription.getAddress(),
                 value: price + 1n,
                 nonce,
                 deadline,

--- a/test/SubscriptionUpgradeable.ts
+++ b/test/SubscriptionUpgradeable.ts
@@ -125,7 +125,7 @@ describe("SubscriptionUpgradeable additional scenarios", function () {
     it("reverts when billingCycle is zero", async function () {
       const { owner, token, proxy } = await loadFixture(deployUpgradeableFixture);
       await expect(
-        proxy.connect(owner).createPlan(owner.address, token.address, 1, 0, false, 0, ethers.ZeroAddress)
+        proxy.connect(owner).createPlan(owner.address, await token.getAddress(), 1, 0, false, 0, ethers.ZeroAddress)
       ).to.be.revertedWith("Billing cycle must be > 0");
     });
   });


### PR DESCRIPTION
## Summary
- update address usage for Hardhat v6

## Testing
- `npm test` *(fails: 26 failing)*

------
https://chatgpt.com/codex/tasks/task_e_686c5b8acdc083338fcbdd38a8672791