### PR TITLE
Fix upgradeable test to use token target

### DIFF
--- a/test/SubscriptionUpgradeable.ts
+++ b/test/SubscriptionUpgradeable.ts
@@ -125,7 +125,9 @@ describe("SubscriptionUpgradeable additional scenarios", function () {
     it("reverts when billingCycle is zero", async function () {
       const { owner, token, proxy } = await loadFixture(deployUpgradeableFixture);
       await expect(
-        proxy.connect(owner).createPlan(owner.address, token.address, 1, 0, false, 0, ethers.ZeroAddress)
+        proxy
+          .connect(owner)
+          .createPlan(owner.address, token.target, 1, 0, false, 0, ethers.ZeroAddress)
       ).to.be.revertedWith("Billing cycle must be > 0");
     });
   });


### PR DESCRIPTION
## Summary
- update token address usage to `token.target` in `SubscriptionUpgradeable` tests

## Testing
- `npx hardhat test test/SubscriptionUpgradeable.ts` *(fails: needs package installation)*
- `npm ci --ignore-scripts --legacy-peer-deps` *(fails: ERESOLVE could not resolve)*

------
https://chatgpt.com/codex/tasks/task_e_686c5b8d04ac8333b8bcb4031ede27dc